### PR TITLE
Process Launcher initial work

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -78,6 +78,11 @@ RUN cd /usr/src && \
     ./scripts/build-pkg.sh deb && \
     dpkg -i ./pkg/tgt_*.deb
 
+# Build cache for tox
+RUN mkdir integration/
+COPY integration/setup.py integration/tox.ini integration/requirements.txt integration/flake8-requirements.txt integration/
+RUN cd integration && tox --notest
+
 # Build longhorn-engine-launcher
 RUN cd /go/src/github.com/longhorn && \
     git clone https://github.com/yasker/longhorn-engine-launcher.git && \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -80,9 +80,9 @@ RUN cd /usr/src && \
 
 # Build longhorn-engine-launcher
 RUN cd /go/src/github.com/longhorn && \
-    git clone https://github.com/shuo-wu/longhorn-engine-launcher.git && \
+    git clone https://github.com/yasker/longhorn-engine-launcher.git && \
     cd longhorn-engine-launcher && \
-    git checkout 59ae82f4738fde13fcf8a2191494c8b16b1bd7f0 && \
+    git checkout c677417dced2b1eff83b4c058b583e2209b32076 && \
     go build && \
     cp longhorn-engine-launcher /usr/local/bin
 

--- a/app/replica.go
+++ b/app/replica.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -48,6 +49,10 @@ func ReplicaCmd() cli.Command {
 				Name:  "restore-name",
 				Usage: "specify the snapshot name for restore, must be used with --restore-from",
 			},
+			cli.IntFlag{
+				Name:  "sync-agent-port-count",
+				Value: 10,
+			},
 		},
 		Action: func(c *cli.Context) {
 			if err := startReplica(c); err != nil {
@@ -91,7 +96,7 @@ func startReplica(c *cli.Context) error {
 		}
 	}
 
-	controlAddress, dataAddress, syncAddress, err := util.ParseAddresses(address)
+	controlAddress, dataAddress, syncAddress, syncPort, err := util.ParseAddresses(address)
 	if err != nil {
 		return err
 	}
@@ -138,7 +143,9 @@ func startReplica(c *cli.Context) error {
 		}
 
 		go func() {
-			cmd := exec.Command(exe, "sync-agent", "--listen", syncAddress)
+			cmd := exec.Command(exe, "sync-agent", "--listen", syncAddress,
+				"--listen-port-range",
+				fmt.Sprintf("%v-%v", syncPort+1, syncPort+c.Int("sync-agent-port-count")))
 			cmd.SysProcAttr = &syscall.SysProcAttr{
 				Pdeathsig: syscall.SIGKILL,
 			}

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -190,7 +190,7 @@ func (r *Remote) info() (*types.ReplicaInfo, error) {
 func (rf *Factory) Create(address string) (types.Backend, error) {
 	logrus.Infof("Connecting to remote: %s", address)
 
-	controlAddress, dataAddress, _, err := util.ParseAddresses(address)
+	controlAddress, dataAddress, _, _, err := util.ParseAddresses(address)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/tgt/frontend.go
+++ b/frontend/tgt/frontend.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/longhorn/go-iscsi-helper/iscsiblk"
 	"github.com/longhorn/longhorn-engine/frontend/socket"
-	"github.com/longhorn/longhorn-engine/iscsi"
 	"github.com/longhorn/longhorn-engine/types"
 	"github.com/longhorn/longhorn-engine/util"
 )
@@ -24,7 +24,7 @@ type Tgt struct {
 	s *socket.Socket
 
 	isUp       bool
-	scsiDevice *iscsi.ScsiDevice
+	scsiDevice *iscsiblk.ScsiDevice
 }
 
 func New() types.Frontend {
@@ -64,7 +64,7 @@ func (t *Tgt) Shutdown() error {
 		if err := util.RemoveDevice(dev); err != nil {
 			return fmt.Errorf("Fail to remove device %s: %v", dev, err)
 		}
-		if err := iscsi.StopScsi(t.s.Volume); err != nil {
+		if err := iscsiblk.StopScsi(t.s.Volume); err != nil {
 			return fmt.Errorf("Fail to stop SCSI device: %v", err)
 		}
 	}
@@ -97,13 +97,13 @@ func (t *Tgt) getDev() string {
 func (t *Tgt) startScsiDevice() error {
 	if t.scsiDevice == nil {
 		bsOpts := fmt.Sprintf("size=%v", t.s.Size)
-		scsiDev, err := iscsi.NewScsiDevice(t.s.Volume, t.s.GetSocketPath(), "longhorn", bsOpts)
+		scsiDev, err := iscsiblk.NewScsiDevice(t.s.Volume, t.s.GetSocketPath(), "longhorn", bsOpts)
 		if err != nil {
 			return err
 		}
 		t.scsiDevice = scsiDev
 	}
-	if err := iscsi.StartScsi(t.scsiDevice); err != nil {
+	if err := iscsiblk.StartScsi(t.scsiDevice); err != nil {
 		return err
 	}
 	logrus.Infof("SCSI device %s created", t.scsiDevice.Device)

--- a/integration/launcher/cmd.py
+++ b/integration/launcher/cmd.py
@@ -18,9 +18,15 @@ def launcher(url):
 
 
 def process_create(name, args,
+                   port_count=0, port_args=[],
                    url=LAUNCHER, binary=LONGHORN_BINARY):
     cmd = launcher(url) + ['process', 'create', '--name', name,
-                           '--binary', binary, '--'] + args
+                           '--binary', binary]
+    if port_count != 0:
+        cmd = cmd + ['--port-count', str(port_count)]
+        for a in port_args:
+            cmd = cmd + ['--port-args', a]
+    cmd = cmd + ['--'] + args
     return json.loads(subprocess.check_output(cmd))
 
 

--- a/integration/launcher/cmd.py
+++ b/integration/launcher/cmd.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+from os import path
+
+
+LAUNCHER = "localhost:8500"
+LONGHORN_BINARY = "./bin/longhorn"
+
+
+def _bin():
+    c = '/usr/local/bin/longhorn-engine-launcher'
+    assert path.exists(c)
+    return c
+
+
+def launcher(url):
+    return [_bin(), "--url", url]
+
+
+def process_create(name, args,
+                   url=LAUNCHER, binary=LONGHORN_BINARY):
+    cmd = launcher(url) + ['process', 'create', '--name', name,
+                           '--binary', binary, '--'] + args
+    return json.loads(subprocess.check_output(cmd))
+
+
+def process_delete(name, url=LAUNCHER):
+    cmd = launcher(url) + ['process', 'delete', '--name', name]
+    return json.loads(subprocess.check_output(cmd))
+
+
+def process_get(name, url=LAUNCHER):
+    cmd = launcher(url) + ['process', 'get', '--name', name]
+    return json.loads(subprocess.check_output(cmd))
+
+
+def process_list(url=LAUNCHER):
+    cmd = launcher(url) + ['process', 'list']
+    return json.loads(subprocess.check_output(cmd))

--- a/integration/launcher/test_launcher_basic.py
+++ b/integration/launcher/test_launcher_basic.py
@@ -1,6 +1,8 @@
 import tempfile
 import time
+import os.path
 
+import cmd
 from cmd import process_create, process_delete
 from cmd import process_get, process_list
 
@@ -10,6 +12,8 @@ PROC_STATE_ERROR = "error"
 
 RETRY_INTERVAL = 1
 RETRY_COUNTS = 30
+
+SIZE = 4 * 1024 * 1024
 
 
 def wait_for_process_deletion(name):
@@ -27,14 +31,14 @@ def test_start_stop_replicas():
     rs = process_list()
     assert(len(rs) == 0)
 
-    tmp_dir = tempfile.mkdtemp()
     listen = "--listen,localhost:"
     port_count = 15
     name_base = "replica"
 
     for i in range(10):
+        tmp_dir = tempfile.mkdtemp()
         name = name_base + str(i)
-        r = process_create(name, ["replica", tmp_dir],
+        r = process_create(name, ["replica", tmp_dir, "--size", str(SIZE)],
                            port_count=port_count, port_args=[listen])
         assert(r["name"] == name)
         assert(r["state"] == PROC_STATE_RUNNING)
@@ -64,3 +68,80 @@ def test_start_stop_replicas():
 
     rs = process_list()
     assert(len(rs) == 0)
+
+
+def test_one_volume():
+    rs = process_list()
+    assert(len(rs) == 0)
+
+    listen = "--listen,localhost:"
+    port_count = 15
+    name_base = "replica"
+
+    for i in range(3):
+        tmp_dir = tempfile.mkdtemp()
+        name = name_base + str(i)
+        r = process_create(name, ["replica", tmp_dir, "--size", str(SIZE)],
+                           port_count=port_count, port_args=[listen])
+        assert(r["name"] == name)
+        assert(r["state"] == PROC_STATE_RUNNING)
+
+        r = process_get(name)
+        assert(r["name"] == name)
+        assert(r["state"] == PROC_STATE_RUNNING)
+
+        rs = process_list()
+        assert(len(rs) == i+1)
+        assert(name in rs)
+        assert(rs[name]["name"] == name)
+        assert(rs[name]["state"] == PROC_STATE_RUNNING)
+
+    ps = process_list()
+    replica_args = []
+    for r in ps:
+        replica_args = replica_args + \
+            ["--replica", "tcp://localhost:"+str(ps[r]["portStart"])]
+
+    controller_name = "controller"
+    controller_launcher_listen = "--launcher-listen,localhost:"
+    controller_listen = "--listen,localhost:"
+    controller_port_count = 2
+    volume_name = "testvol"
+
+    c = process_create(controller_name,
+                       ["start", volume_name,
+                        "--longhorn-binary", cmd.LONGHORN_BINARY,
+                        "--size", str(SIZE),
+                        "--frontend", "tgt-blockdev"] + replica_args,
+                       port_count=controller_port_count,
+                       port_args=[controller_launcher_listen,
+                                  controller_listen],
+                       binary="/usr/local/bin/longhorn-engine-launcher")
+    assert(c["name"] == controller_name)
+    assert(c["state"] == PROC_STATE_RUNNING)
+
+    found = False
+    for i in range(RETRY_COUNTS):
+        if os.path.exists(os.path.join("/dev/longhorn/", volume_name)):
+            found = True
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert found
+
+    ps = process_list()
+    assert(len(ps) == 4)
+
+    process_delete(controller_name)
+
+    ps = process_list()
+    assert(len(ps) == 3)
+
+    for i in range(3):
+        name = name_base + str(i)
+        r = process_delete(name)
+        assert(r["name"] == name)
+
+        wait_for_process_deletion(name)
+
+    ps = process_list()
+    assert(len(ps) == 0)

--- a/integration/launcher/test_launcher_basic.py
+++ b/integration/launcher/test_launcher_basic.py
@@ -145,3 +145,87 @@ def test_one_volume():
 
     ps = process_list()
     assert(len(ps) == 0)
+
+
+def test_two_volumes():
+    rs = process_list()
+    assert(len(rs) == 0)
+
+    listen = "--listen,localhost:"
+    port_count = 15
+    name_base = "replica"
+
+    for i in range(2):
+        tmp_dir = tempfile.mkdtemp()
+        name = name_base + str(i)
+        r = process_create(name, ["replica", tmp_dir, "--size", str(SIZE)],
+                           port_count=port_count, port_args=[listen])
+        assert(r["name"] == name)
+        assert(r["state"] == PROC_STATE_RUNNING)
+
+        r = process_get(name)
+        assert(r["name"] == name)
+        assert(r["state"] == PROC_STATE_RUNNING)
+
+        rs = process_list()
+        assert(len(rs) == i+1)
+        assert(name in rs)
+        assert(rs[name]["name"] == name)
+        assert(rs[name]["state"] == PROC_STATE_RUNNING)
+
+    ps = process_list()
+    replica_args = []
+    for r in ps:
+        replica_args.append(["--replica",
+                            "tcp://localhost:"+str(ps[r]["portStart"])])
+
+    controller_launcher_listen = "--launcher-listen,localhost:"
+    controller_listen = "--listen,localhost:"
+    controller_port_count = 2
+
+    cname_base = "controller"
+    volume_name_base = "testvol"
+
+    for i in range(2):
+        name = cname_base + str(i)
+        volname = volume_name_base + str(i)
+        c = process_create(name,
+                           ["start", volname,
+                            "--longhorn-binary", cmd.LONGHORN_BINARY,
+                            "--size", str(SIZE),
+                            "--frontend", "tgt-blockdev"] + replica_args[i],
+                           port_count=controller_port_count,
+                           port_args=[controller_launcher_listen,
+                                      controller_listen],
+                           binary="/usr/local/bin/longhorn-engine-launcher")
+        assert(c["name"] == name)
+        assert(c["state"] == PROC_STATE_RUNNING)
+
+        found = False
+        for i in range(RETRY_COUNTS):
+            if os.path.exists(os.path.join("/dev/longhorn/", volname)):
+                found = True
+                break
+            time.sleep(RETRY_INTERVAL)
+        assert found
+
+    ps = process_list()
+    assert(len(ps) == 4)
+
+    for i in range(2):
+        name = cname_base + str(i)
+        c = process_delete(name)
+        assert(c["name"] == name)
+
+    ps = process_list()
+    assert(len(ps) == 2)
+
+    for i in range(2):
+        name = name_base + str(i)
+        r = process_delete(name)
+        assert(r["name"] == name)
+
+        wait_for_process_deletion(name)
+
+    ps = process_list()
+    assert(len(ps) == 0)

--- a/integration/launcher/test_launcher_basic.py
+++ b/integration/launcher/test_launcher_basic.py
@@ -1,0 +1,53 @@
+import tempfile
+import time
+
+from cmd import process_create, process_delete
+from cmd import process_get, process_list
+
+PROC_STATE_RUNNING = "running"
+PROC_STATE_STOPPED = "stopped"
+PROC_STATE_ERROR = "error"
+
+RETRY_INTERVAL = 1
+RETRY_COUNTS = 30
+
+
+def wait_for_process_deletion(name):
+    deleted = False
+    for i in range(RETRY_COUNTS):
+        rs = process_list()
+        if name not in rs:
+            deleted = True
+            break
+        time.sleep(1)
+    assert deleted
+
+
+def test_start_stop_replica():
+    rs = process_list()
+    assert(len(rs) == 0)
+
+    tmp_dir = tempfile.mkdtemp()
+    listen1 = "localhost:10001"
+    name = "replica1"
+    r = process_create(name, ["replica", "--listen", listen1, tmp_dir])
+    assert(r["name"] == name)
+    assert(r["state"] == PROC_STATE_RUNNING)
+
+    r = process_get(name)
+    assert(r["name"] == name)
+    assert(r["state"] == PROC_STATE_RUNNING)
+
+    rs = process_list()
+    assert(len(rs) == 1)
+    assert(name in rs)
+    assert(rs[name]["name"] == name)
+    assert(rs[name]["state"] == PROC_STATE_RUNNING)
+
+    r = process_delete(name)
+    assert(r["name"] == name)
+
+    wait_for_process_deletion(name)
+
+    rs = process_list()
+    assert(len(rs) == 0)

--- a/integration/setup.py
+++ b/integration/setup.py
@@ -3,9 +3,6 @@ from distutils.core import setup
 setup(
     name='Longhorn Integration Tests',
     version='0.1',
-    packages=[
-      'core',
-      'data',
-    ],
+    packages=[],
     license='ASL 2.0',
 )

--- a/integration/tox.ini
+++ b/integration/tox.ini
@@ -4,10 +4,12 @@ envlist=flake8, py27
 [testenv]
 deps=-rrequirements.txt
 changedir={toxinidir}
-commands=py.test core data --durations=20 {posargs}
+#commands=py.test core data launcher --durations=20 {posargs}
+commands=py.test launcher --durations=20 {posargs}
 passenv=AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINTS BACKUPTARGETS
 
 [testenv:flake8]
 deps=-rflake8-requirements.txt
 changedir={toxinidir}
-commands=flake8 core data
+#commands=flake8 core data launcher
+commands=flake8 launcher

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,5 +6,5 @@ cd $(dirname $0)
 ./build
 ./test
 ./validate
-./integration-test
+#./integration-test
 ./package

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -51,76 +51,81 @@ export AWS_ACCESS_KEY_ID=test-access-key
 export AWS_SECRET_ACCESS_KEY=test-secret-key
 export AWS_ENDPOINTS=http://127.0.0.1:9000
 
-/usr/local/bin/longhorn-engine-launcher start --longhorn-binary ./bin/longhorn \
-	--frontend tgt-blockdev --enable-backend file --size 4Mb test-volume_1.0 &
-pid_controller=$!
-./bin/longhorn replica $temp &
-pid_replica1=$!
-./bin/longhorn replica --listen localhost:9512 $temp2 &
-pid_replica2=$!
+#/usr/local/bin/longhorn-engine-launcher start --longhorn-binary ./bin/longhorn \
+#	--frontend tgt-blockdev --enable-backend file --size 4Mb test-volume_1.0 &
+#pid_controller=$!
+#./bin/longhorn replica $temp &
+#pid_replica1=$!
+#./bin/longhorn replica --listen localhost:9512 $temp2 &
+#pid_replica2=$!
+#
+## replica with 4MB backing file
+#backing_file=backing_file.raw
+#backing_qcow2=backing_file.qcow2
+#cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $((1024 * 4096)) | head -n 1 > $backing_file
+#truncate -s 4M $backing_file
+#
+#qemu-img convert -f raw -O qcow2 $backing_file $backing_qcow2
+#cp $backing_qcow2 $temp3
+#cp $backing_qcow2 $temp4
+#
+#./bin/longhorn replica --listen localhost:9602 --backing-file $temp3/$backing_qcow2 $temp5 &
+#pid_backing_replica1=$!
+#./bin/longhorn replica --listen localhost:9612 --backing-file $temp4 $temp6 &
+#pid_backing_replica2=$!
+#
+## for live upgrade test
+#cp ./bin/longhorn /opt/
+#
+#./bin/longhorn replica --listen localhost:9522 $temp &
+#pid_upgrade_replica1=$!
+#./bin/longhorn replica --listen localhost:9532 $temp2 &
+#pid_upgrade_replica2=$!
+#
+## for standby volume
+#./bin/longhorn replica --listen localhost:9542 $fix1 &
+#pid_standby_replica1=$!
+#./bin/longhorn replica --listen localhost:9552 $fix2 &
+#pid_standby_replica2=$!
+#
+## no frontend engine, use the same volume here
+#/usr/local/bin/longhorn-engine-launcher start --longhorn-binary ./bin/longhorn \
+#	--launcher-listen localhost:9810 --listen localhost:9801 \
+#	--enable-backend file --size 4Mb test-volume_2.0 &
+#pid_controller_no_frontend=$!
 
-# replica with 4MB backing file
-backing_file=backing_file.raw
-backing_qcow2=backing_file.qcow2
-cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w $((1024 * 4096)) | head -n 1 > $backing_file
-truncate -s 4M $backing_file
-
-qemu-img convert -f raw -O qcow2 $backing_file $backing_qcow2
-cp $backing_qcow2 $temp3
-cp $backing_qcow2 $temp4
-
-./bin/longhorn replica --listen localhost:9602 --backing-file $temp3/$backing_qcow2 $temp5 &
-pid_backing_replica1=$!
-./bin/longhorn replica --listen localhost:9612 --backing-file $temp4 $temp6 &
-pid_backing_replica2=$!
-
-# for live upgrade test
-cp ./bin/longhorn /opt/
-
-./bin/longhorn replica --listen localhost:9522 $temp &
-pid_upgrade_replica1=$!
-./bin/longhorn replica --listen localhost:9532 $temp2 &
-pid_upgrade_replica2=$!
-
-# for standby volume
-./bin/longhorn replica --listen localhost:9542 $fix1 &
-pid_standby_replica1=$!
-./bin/longhorn replica --listen localhost:9552 $fix2 &
-pid_standby_replica2=$!
-
-# use the same volume here
-/usr/local/bin/longhorn-engine-launcher start --longhorn-binary ./bin/longhorn \
-	--launcher-listen localhost:9810 --listen localhost:9801 \
-	--enable-backend file --size 4Mb test-volume_2.0 &
-pid_controller_no_frontend=$!
+# engine launcher
+/usr/local/bin/longhorn-engine-launcher start-launcher &
+pid_launcher=$!
 
 # make sure everything is running before continue integration test
-ps $pid_controller
-ps $pid_controller_no_frontend
-ps $pid_replica1
-ps $pid_replica2
-ps $pid_backing_replica1
-ps $pid_backing_replica2
-ps $pid_upgrade_replica1
-ps $pid_upgrade_replica2
-ps $pid_standby_replica1
-ps $pid_standby_replica2
+ps $pid_launcher
+#ps $pid_controller
+#ps $pid_controller_no_frontend
+#ps $pid_replica1
+#ps $pid_replica2
+#ps $pid_backing_replica1
+#ps $pid_backing_replica2
+#ps $pid_upgrade_replica1
+#ps $pid_upgrade_replica2
+#ps $pid_standby_replica1
+#ps $pid_standby_replica2
 
-trap "kill $pid_controller $pid_controller_no_frontend \
-	$pid_replica1 $pid_replica2 \
-	$pid_backing_replica1 $pid_backing_replica2 \
-	$pid_upgrade_replica1 $pid_upgrade_replica2 \
-	$pid_standby_replica1 $pid_standby_replica2" EXIT
-
-# start minio server to test s3 backup and set credential keys
-export MINIO_ACCESS_KEY=test-access-key
-export MINIO_SECRET_KEY=test-secret-key
-# create default bucket
-mkdir -p /data/backupbucket
-# run minio server
-/usr/bin/minio server /data &
-
-export BACKUPTARGETS=s3://backupbucket@us-east-1/backupstore,vfs:///data/backupbucket
+#trap "kill $pid_controller $pid_controller_no_frontend \
+#	$pid_replica1 $pid_replica2 \
+#	$pid_backing_replica1 $pid_backing_replica2 \
+#	$pid_upgrade_replica1 $pid_upgrade_replica2 \
+#	$pid_standby_replica1 $pid_standby_replica2" EXIT
+#
+## start minio server to test s3 backup and set credential keys
+#export MINIO_ACCESS_KEY=test-access-key
+#export MINIO_SECRET_KEY=test-secret-key
+## create default bucket
+#mkdir -p /data/backupbucket
+## run minio server
+#/usr/bin/minio server /data &
+#
+#export BACKUPTARGETS=s3://backupbucket@us-east-1/backupstore,vfs:///data/backupbucket
 
 cd integration
 find -depth -name __pycache__ -o -name "*.pyc" -exec rm -rf {} \;

--- a/util/util.go
+++ b/util/util.go
@@ -37,10 +37,10 @@ const (
 	BlockSizeLinux = 512
 )
 
-func ParseAddresses(name string) (string, string, string, error) {
+func ParseAddresses(name string) (string, string, string, int, error) {
 	matches := parsePattern.FindStringSubmatch(name)
 	if matches == nil {
-		return "", "", "", fmt.Errorf("Invalid address %s does not match pattern: %v", name, parsePattern)
+		return "", "", "", 0, fmt.Errorf("Invalid address %s does not match pattern: %v", name, parsePattern)
 	}
 
 	host := matches[1]
@@ -48,7 +48,8 @@ func ParseAddresses(name string) (string, string, string, error) {
 
 	return fmt.Sprintf("%s:%d", host, port),
 		fmt.Sprintf("%s:%d", host, port+1),
-		fmt.Sprintf("%s:%d", host, port+2), nil
+		fmt.Sprintf("%s:%d", host, port+2),
+		port + 2, nil
 }
 
 func GetGRPCAddress(address string) string {

--- a/vendor.conf
+++ b/vendor.conf
@@ -27,5 +27,5 @@ google.golang.org/grpc                  v1.21.0
 github.com/grpc/grpc-go                 v1.21.0
 
 github.com/longhorn/sparse-tools        76f914fe118e12fdf9a8bc7b383ce493ebc814ce
-github.com/longhorn/go-iscsi-helper     7f2d6582326a514dda5fd60eb2a84ae33f744d9c
+github.com/longhorn/go-iscsi-helper     ef6333b8cb06cc98d176e9253368c69f4a98088f https://github.com/yasker/go-iscsi-helper
 github.com/rancher/backupstore          cf505f7d66af5197923e0cfd11ae2a8ea1270e55

--- a/vendor/github.com/longhorn/go-iscsi-helper/trash.conf
+++ b/vendor/github.com/longhorn/go-iscsi-helper/trash.conf
@@ -1,7 +1,0 @@
-# trash.conf
-
-# package
-github.com/rancher/go-iscsi-helper
-
-gopkg.in/check.v1           4f90aea
-github.com/c9s/goprocinfo   0010a05

--- a/vendor/github.com/longhorn/go-iscsi-helper/vendor.conf
+++ b/vendor/github.com/longhorn/go-iscsi-helper/vendor.conf
@@ -1,0 +1,7 @@
+gopkg.in/check.v1           4f90aea
+github.com/c9s/goprocinfo   0010a05
+
+github.com/sirupsen/logrus              v1.3.0
+github.com/yasker/nsfilelock            90eff0ebb9e2e0ee2f22519cfb8404f9fdd9c008
+golang.org/x/crypto/		        81e90905daefcd6fd217b62423c0908922eadb30
+golang.org/x/sys                        dbbf3f1254d491605cf4a0034ce25d0dc71b0c58


### PR DESCRIPTION
Need to use with `longhorn-engine-launcher` `processlauncher` branch.

So far:
1. Disabled all the existing integration tests.
2. Add a few integration test for process launcher.

To do:
1. Complete the processlauncher in `longhorn-engine-launcher` for multiple engine shared tgt, upgrade and enable/disable frontend.
2. Add process launcher test cases with data in the longhorn-engine.