### PR TITLE
Frontend shutdown before snapshot revert

### DIFF
--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -389,8 +389,9 @@ def test_revert(grpc_controller_client,
                         'volume-snap-foo1.img']
     assert r1.chain == r2.chain
 
+    shutdown_engine_frontend()
     grpc_controller_client.volume_revert(name='foo1')
-
+    start_engine_frontend(FRONTEND_TGT_BLOCKDEV)
     r1 = grpc_replica_client.replica_get()
     r2 = grpc_replica_client2.replica_get()
     assert r1.chain == ['volume-head-003.img', 'volume-snap-foo1.img']

--- a/integration/data/common.py
+++ b/integration/data/common.py
@@ -16,6 +16,7 @@ import launcher
 from cmd import snapshot_create
 from cmd import RETRY_COUNTS
 from cmd import backup_restore
+from cmd import snapshot_revert
 from utils import read_file, checksum_data, SIZE
 from frontend import restdev, blockdev
 from frontend import PAGE_SIZE, LONGHORN_DEV_DIR, get_socket_path  # NOQA
@@ -149,6 +150,12 @@ def restore_with_no_frontend(backup, grpc_c):
     launcher.start_engine_frontend(FRONTEND_TGT_BLOCKDEV)
     v = grpc_c.volume_get()
     assert v.frontendState == "up"
+
+
+def snapshot_revert_with_frontend(name):
+    launcher.shutdown_engine_frontend()
+    snapshot_revert(name)
+    launcher.start_engine_frontend(FRONTEND_TGT_BLOCKDEV)
 
 
 @pytest.fixture()

--- a/integration/data/snapshot_tree.py
+++ b/integration/data/snapshot_tree.py
@@ -17,19 +17,19 @@ def snapshot_tree_build(dev, offset, length, strict=True):
     snapshot_tree_create_node(dev, offset, length, snap, data, "0b")
     snapshot_tree_create_node(dev, offset, length, snap, data, "0c")
 
-    cmd.snapshot_revert(snap["0b"])
+    common.snapshot_revert_with_frontend(snap["0b"])
 
     snapshot_tree_create_node(dev, offset, length, snap, data, "1a")
     snapshot_tree_create_node(dev, offset, length, snap, data, "1b")
     snapshot_tree_create_node(dev, offset, length, snap, data, "1c")
 
-    cmd.snapshot_revert(snap["0b"])
+    common.snapshot_revert_with_frontend(snap["0b"])
 
     snapshot_tree_create_node(dev, offset, length, snap, data, "2a")
     snapshot_tree_create_node(dev, offset, length, snap, data, "2b")
     snapshot_tree_create_node(dev, offset, length, snap, data, "2c")
 
-    cmd.snapshot_revert(snap["2a"])
+    common.snapshot_revert_with_frontend(snap["2a"])
 
     snapshot_tree_create_node(dev, offset, length, snap, data, "3a")
     snapshot_tree_create_node(dev, offset, length, snap, data, "3b")
@@ -142,7 +142,7 @@ def snapshot_tree_verify_data(dev, offset, length, snap, data):
 
 
 def snapshot_tree_verify_node(dev, offset, length, snap, data, name):
-    cmd.snapshot_revert(snap[name])
+    common.snapshot_revert_with_frontend(snap[name])
     readed = read_dev(dev, offset, length)
     assert readed == data[name]
 

--- a/integration/data/test_snapshot.py
+++ b/integration/data/test_snapshot.py
@@ -2,6 +2,7 @@ import cmd
 from common import dev, backing_dev  # NOQA
 from common import read_dev, read_from_backing_file, VOLUME_HEAD
 from common import Snapshot, generate_random_data
+from common import snapshot_revert_with_frontend
 from snapshot_tree import snapshot_tree_build, snapshot_tree_verify_node
 
 
@@ -17,12 +18,12 @@ def test_snapshot_revert(dev):  # NOQA
     assert snap2.name in snapList
     assert snap3.name in snapList
 
-    cmd.snapshot_revert(snap2.name)
+    snapshot_revert_with_frontend(snap2.name)
     snap3.refute_data()
     snap2.verify_checksum()
     snap1.verify_data()
 
-    cmd.snapshot_revert(snap1.name)
+    snapshot_revert_with_frontend(snap1.name)
     snap3.refute_data()
     snap2.refute_data()
     snap1.verify_checksum()
@@ -55,7 +56,7 @@ def test_snapshot_rm_basic(dev):  # NOQA
     snap2.verify_data()
     snap1.verify_data()
 
-    cmd.snapshot_revert(snap1.name)
+    snapshot_revert_with_frontend(snap1.name)
     snap3.refute_data()
     snap2.refute_data()
     snap1.verify_checksum()
@@ -81,7 +82,7 @@ def test_snapshot_revert_with_backing_file(backing_dev):  # NOQA
 
     test_snapshot_revert(dev)
 
-    cmd.snapshot_revert(snap0)
+    snapshot_revert_with_frontend(snap0)
     after = read_dev(dev, offset, length)
     assert before == after
 
@@ -163,7 +164,7 @@ def test_snapshot_tree_basic(dev):  # NOQA
 
     snap, data = snapshot_tree_build(dev, offset, length)
 
-    cmd.snapshot_revert(snap["1b"])
+    snapshot_revert_with_frontend(snap["1b"])
     cmd.snapshot_rm(snap["0a"])
     cmd.snapshot_rm(snap["0b"])
     cmd.snapshot_rm(snap["1c"])


### PR DESCRIPTION
The following changes include two things:
1. Integration test to manually shutdown before snapshot revert operation and start the launcher after snapshot revert completion.
2. Modify the controller logic in revert to check if the frontend is disabled before performing snapshot revert. Otherwise, abort the snapshot revert.