### PR TITLE
Restore Status changing json name for restore error

### DIFF
--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -686,8 +686,8 @@ def restore_backup(bin, backupURL, env, grpc_c):
             if 'progress' in status.keys() and status['progress'] == 100:
                 completed += 1
                 continue
-            if 'restoreError' in status.keys():
-                assert status['restoreError'] == ""
+            if 'error' in status.keys():
+                assert status['error'] == ""
         if completed == len(rs):
             return
     assert completed == len(rs)

--- a/integration/data/cmd.py
+++ b/integration/data/cmd.py
@@ -85,8 +85,8 @@ def wait_for_restore_completion(url):
         for status in rs.values():
             if 'progress' in status.keys() and status['progress'] == 100:
                 completed += 1
-            if 'restoreError' in status.keys():
-                assert status['restoreError'] == ""
+            if 'error' in status.keys():
+                assert status['error'] == ""
         if completed == len(rs):
             return
     assert completed == len(rs)

--- a/sync/backup.go
+++ b/sync/backup.go
@@ -25,7 +25,7 @@ type RestoreStatus struct {
 	IsRestoring  bool   `json:"isRestoring"`
 	LastRestored string `json:"lastRestored"`
 	Progress     int    `json:"progress,omitempty"`
-	RestoreError string `json:"restoreError,omitempty"`
+	Error        string `json:"error,omitempty"`
 	Filename     string `json:"filename,omitempty"`
 }
 
@@ -356,7 +356,7 @@ func (t *Task) RestoreStatus() (map[string]*RestoreStatus, error) {
 			IsRestoring:  rs.IsRestoring,
 			LastRestored: rs.LastRestored,
 			Progress:     int(rs.Progress),
-			RestoreError: rs.Error,
+			Error:        rs.Error,
 			Filename:     rs.DestFileName,
 		}
 	}


### PR DESCRIPTION
Earlier, the restore status had `restoreError` JSON tag for the attribute RestoreError. Going forward we are changing it to `error` as it's already part of RestoreStatus message.