### PR TITLE
Renames related to backup

### DIFF
--- a/backup/main.go
+++ b/backup/main.go
@@ -55,7 +55,8 @@ func RequiredMissingError(name string) error {
 	return fmt.Errorf("Cannot find valid required parameter: %v", name)
 }
 
-func DoBackupCreate(volumeName string, snapshotName string, destURL string, labels []string) (string, *replica.Backup, error) {
+func DoBackupCreate(volumeName string, snapshotName string, destURL string,
+	labels []string) (string, *replica.BackupStatus, error) {
 	var (
 		err         error
 		backingFile *replica.BackingFile

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -660,8 +660,8 @@ def get_backup_url(bin, backupID):
         if backup['progress'] == 100 and 'backupURL' in backup.keys():
             rValue = backup['backupURL']
             break
-        elif 'backupError' in backup.keys():
-            rValue = backup['backupError']
+        elif 'error' in backup.keys():
+            rValue = backup['error']
             break
         time.sleep(1)
     return rValue

--- a/integration/data/cmd.py
+++ b/integration/data/cmd.py
@@ -68,8 +68,8 @@ def backup_status(backupID, url=CONTROLLER):
         if 'backupURL' in backup.keys():
             output = backup['backupURL']
             break
-        elif 'backupError' in backup.keys():
-            output = backup['backupError']
+        elif 'error' in backup.keys():
+            output = backup['error']
             break
         time.sleep(1)
     return output

--- a/sync/backup.go
+++ b/sync/backup.go
@@ -17,7 +17,7 @@ import (
 type BackupStatusInfo struct {
 	Progress     int    `json:"progress"`
 	BackupURL    string `json:"backupURL,omitempty"`
-	BackupError  string `json:"backupError,omitempty"`
+	Error        string `json:"error,omitempty"`
 	SnapshotName string `json:"snapshotName"`
 }
 
@@ -112,7 +112,7 @@ func (t *Task) FetchBackupStatus(backupID string, replicaIP string) (*BackupStat
 	info := &BackupStatusInfo{
 		Progress:     progress,
 		BackupURL:    url,
-		BackupError:  backupErr,
+		Error:        backupErr,
 		SnapshotName: snapshot,
 	}
 


### PR DESCRIPTION
The following code modifications include renaming `backupError` to
`error`. Further, the replica backup object name
is changed from `Backup` to `BackupStatus` and it's attributes
`BackupProgress` and `BackupError` to `Progress` and `Error`
respectively.