### PR TITLE
Remove the timeout logic from Backup Restore

### DIFF
--- a/app/restore_to_file.go
+++ b/app/restore_to_file.go
@@ -25,7 +25,6 @@ const (
 	BackupFileConverted   = "backup.img.converted"
 	BackingFileCopy       = "backing.img.cp"
 
-	ProgressBasedTimeoutInMinutes    = 5
 	PeriodicRefreshIntervalInSeconds = 2
 )
 
@@ -86,7 +85,6 @@ func restore(url string) error {
 		restoreObj.Lock()
 		restoreProgress := restoreObj.Progress
 		restoreError := restoreObj.Error
-		lastUpdate := restoreObj.LastUpdatedAt
 		restoreObj.Unlock()
 
 		if restoreProgress == 100 {
@@ -99,14 +97,6 @@ func restore(url string) error {
 			bar.Finish()
 			periodicChecker.Stop()
 			return fmt.Errorf("%v", restoreError)
-		}
-		now := time.Now()
-		diff := now.Sub(lastUpdate)
-
-		if diff.Minutes() > ProgressBasedTimeoutInMinutes {
-			bar.Finish()
-			periodicChecker.Stop()
-			return fmt.Errorf("no restore update happened since %v minutes. Returning failure", ProgressBasedTimeoutInMinutes)
 		}
 		bar.Set(restoreProgress)
 	}

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -37,7 +36,6 @@ type RestoreStatus struct {
 	SnapshotName   string //This will be deltaFileName in case of Incremental Restore
 	Progress       int
 	Error          string
-	LastUpdatedAt  time.Time
 	BackupURL      string
 	State          ProgressState
 
@@ -64,7 +62,6 @@ func (rr *RestoreStatus) UpdateRestoreStatus(snapshot string, rp int, re error) 
 		rr.Error = re.Error()
 		rr.State = ProgressStateError
 	}
-	rr.LastUpdatedAt = time.Now()
 }
 
 func (rr *RestoreStatus) FinishRestore() {

--- a/sync/rpc/server.go
+++ b/sync/rpc/server.go
@@ -27,7 +27,6 @@ import (
 const (
 	MaxBackupSize = 5
 
-	ProgressBasedTimeoutInMinutes    = 5
 	PeriodicRefreshIntervalInSeconds = 2
 
 	GRPCServiceCommonTimeout = 1 * time.Minute
@@ -366,7 +365,6 @@ func (s *SyncAgentServer) waitForRestoreComplete() error {
 		s.RestoreInfo.Lock()
 		restoreProgress = s.RestoreInfo.Progress
 		restoreError = s.RestoreInfo.Error
-		lastUpdate := s.RestoreInfo.LastUpdatedAt
 		s.RestoreInfo.Unlock()
 
 		if restoreProgress == 100 {
@@ -378,16 +376,6 @@ func (s *SyncAgentServer) waitForRestoreComplete() error {
 			logrus.Errorf("Backup Restore Error Found in Server[%v]", restoreError)
 			periodicChecker.Stop()
 			return fmt.Errorf("%v", restoreError)
-		}
-		now := time.Now()
-		diff := now.Sub(lastUpdate)
-
-		if diff.Minutes() > ProgressBasedTimeoutInMinutes {
-			logrus.Errorf("no restore update happened since %v minutes. Returning failure",
-				ProgressBasedTimeoutInMinutes)
-			periodicChecker.Stop()
-			return fmt.Errorf("no restore update happened since %v minutes. Returning failure",
-				ProgressBasedTimeoutInMinutes)
 		}
 	}
 	return nil
@@ -462,7 +450,6 @@ func (s *SyncAgentServer) completeBackupRestore() (err error) {
 		SnapshotName:     s.RestoreInfo.SnapshotName,
 		Progress:         s.RestoreInfo.Progress,
 		Error:            s.RestoreInfo.Error,
-		LastUpdatedAt:    s.RestoreInfo.LastUpdatedAt,
 		LastRestored:     s.RestoreInfo.LastRestored,
 		SnapshotDiskName: s.RestoreInfo.SnapshotDiskName,
 		BackupURL:        s.RestoreInfo.BackupURL,
@@ -661,7 +648,6 @@ func (s *SyncAgentServer) completeIncrementalBackupRestore() (err error) {
 		SnapshotName:     s.RestoreInfo.SnapshotName,
 		Progress:         s.RestoreInfo.Progress,
 		Error:            s.RestoreInfo.Error,
-		LastUpdatedAt:    s.RestoreInfo.LastUpdatedAt,
 		LastRestored:     s.RestoreInfo.LastRestored,
 		SnapshotDiskName: s.RestoreInfo.SnapshotDiskName,
 		BackupURL:        s.RestoreInfo.BackupURL,


### PR DESCRIPTION
The following code changes removes the timeout logic from the backup restore. This includes removing from the restore_to_file path as well.

Issue: https://github.com/longhorn/longhorn/issues/644