### PR TITLE
Use `tini` as the entry point for the instance manager

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,4 +18,10 @@ RUN dpkg -i /opt/tgt_*.deb
 
 VOLUME /usr/local/bin
 
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 CMD ["longhorn"]


### PR DESCRIPTION
Make sure the children process are reaped correctly.

https://github.com/longhorn/longhorn/issues/795

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>