### PR TITLE
instance manager: Make sure the engine launcher can be cleaned up

### DIFF
--- a/pkg/instance-manager/engine/engine_manager.go
+++ b/pkg/instance-manager/engine/engine_manager.go
@@ -211,7 +211,11 @@ func (em *Manager) EngineDelete(ctx context.Context, req *rpc.EngineRequest) (re
 	}
 
 	if err := el.Stop(); err != nil {
-		return nil, err
+		if statusCode, ok := status.FromError(err); ok && statusCode.Code() == codes.NotFound {
+			logrus.Warnf("Engine Manager: The related engine process of engine launcher %v is not found. But engine manager will continue cleaning up the engine launcher", el.LauncherName)
+		} else {
+			return nil, err
+		}
 	}
 
 	go em.unregisterEngineLauncher(req.Name)

--- a/pkg/instance-manager/types/types.go
+++ b/pkg/instance-manager/types/types.go
@@ -18,3 +18,8 @@ var (
 	WaitInterval = 100 * time.Millisecond
 	WaitCount    = 600
 )
+
+const (
+	RetryInterval = 3 * time.Second
+	RetryCounts   = 3
+)


### PR DESCRIPTION
even if the related process is not found or the frontend cleanup fails

https://github.com/longhorn/longhorn/issues/854
https://github.com/longhorn/longhorn/issues/923