### PR TITLE
test: Avoid ephemeral port range

### DIFF
--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -78,7 +78,7 @@ cp -a ./bin/longhorn /opt/
 
 /usr/local/bin/longhorn-instance-manager --debug daemon &
 pid_imr=$!
-/usr/local/bin/longhorn-instance-manager --debug daemon --listen localhost:8501 --port-range 35000-40000 &
+/usr/local/bin/longhorn-instance-manager --debug daemon --listen localhost:8501 --port-range 30001-32000 &
 pid_ime=$!
 
 # make sure everything is running before continue integration test


### PR DESCRIPTION
It's 32768 to 60999 by default in Linux.

https://github.com/longhorn/longhorn/issues/1085