### PR TITLE
Add support for custom ssl certificates for S3 backups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200410230022-28cbdac36bf4
+	github.com/longhorn/backupstore v0.0.0-20200428191103-882e4d6f20a5
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200410230022-28cbdac36bf4 h1:17Z9Eca1N1N4TrUREJdPM0LOTrhAbBXpTTG/Op9zaUg=
-github.com/longhorn/backupstore v0.0.0-20200410230022-28cbdac36bf4/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200428191103-882e4d6f20a5 h1:ax+sRzJUwJ7ixEnxHojTYVlFNr30LdodwQwh58YRO1A=
+github.com/longhorn/backupstore v0.0.0-20200428191103-882e4d6f20a5/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487 h1:ARgyOW/q9zb2MS5EEX3X9frQhBtpeSX4PVf9DJXTUy4=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/integration/tox.ini
+++ b/integration/tox.ini
@@ -5,7 +5,7 @@ envlist=flake8, py36
 deps=-rrequirements.txt
 changedir={toxinidir}
 commands=py.test core data instance --durations=20 {posargs}
-passenv=AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINTS BACKUPTARGETS TESTPREFIX
+passenv=AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINTS AWS_CERT BACKUPTARGETS TESTPREFIX
 
 [testenv:flake8]
 deps=-rflake8-requirements.txt

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -431,6 +431,11 @@ func (s *SyncAgentServer) BackupCreate(ctx context.Context, req *ptypes.BackupCr
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+
+			// set a custom ca cert if available
+			if credential[types.AWSCert] != "" {
+				os.Setenv(types.AWSCert, credential[types.AWSCert])
+			}
 		} else if os.Getenv(types.AWSAccessKey) == "" || os.Getenv(types.AWSSecretKey) == "" {
 			return nil, errors.New("Could not backup to s3 without setting credential secret")
 		}
@@ -541,6 +546,11 @@ func (s *SyncAgentServer) BackupRestore(ctx context.Context, req *ptypes.BackupR
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+
+			// set a custom ca cert if available
+			if credential[types.AWSCert] != "" {
+				os.Setenv(types.AWSCert, credential[types.AWSCert])
+			}
 		} else if os.Getenv(types.AWSAccessKey) == "" || os.Getenv(types.AWSSecretKey) == "" {
 			return nil, errors.New("Could not backup to s3 without setting credential secret")
 		}
@@ -736,6 +746,11 @@ func (s *SyncAgentServer) BackupRestoreIncrementally(ctx context.Context,
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+
+			// set a custom ca cert if available
+			if credential[types.AWSCert] != "" {
+				os.Setenv(types.AWSCert, credential[types.AWSCert])
+			}
 		} else if os.Getenv(types.AWSAccessKey) == "" || os.Getenv(types.AWSSecretKey) == "" {
 			return nil, errors.New("Could not backup to s3 without setting credential secret")
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,6 +21,7 @@ const (
 	AWSAccessKey = "AWS_ACCESS_KEY_ID"
 	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
 	AWSEndPoint  = "AWS_ENDPOINTS"
+	AWSCert      = "AWS_CERT"
 
 	RetryCounts   = 30
 	RetryInterval = 1 * time.Second

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -270,6 +270,7 @@ func GetBackupCredential(backupURL string) (map[string]string, error) {
 		credential[types.AWSAccessKey] = accessKey
 		credential[types.AWSSecretKey] = secretKey
 		credential[types.AWSEndPoint] = os.Getenv(types.AWSEndPoint)
+		credential[types.AWSCert] = os.Getenv(types.AWSCert)
 	}
 	return credential, nil
 }

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -61,7 +61,26 @@ fi
 # set credential for replica to test backup restore
 export AWS_ACCESS_KEY_ID=test-access-key
 export AWS_SECRET_ACCESS_KEY=test-secret-key
-export AWS_ENDPOINTS=http://127.0.0.1:9000
+export AWS_ENDPOINTS=https://127.0.0.1:9000
+export AWS_CERT="-----BEGIN CERTIFICATE-----
+MIIDLDCCAhSgAwIBAgIRAMdo42phTeyk17/bLrZ5YDswDQYJKoZIhvcNAQELBQAw
+GjEYMBYGA1UEChMPTG9uZ2hvcm4gLSBUZXN0MCAXDTIwMDQyNzIzMDAxMVoYDzIx
+MjAwNDAzMjMwMDExWjAaMRgwFgYDVQQKEw9Mb25naG9ybiAtIFRlc3QwggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDXzUurgPZDgzT3DYuaebgewqowdeAD
+84VYazfSuQ+7+mNkiiQPozUU2foQaF/PqzBbQmegoaOyy5Xj3UExmFretx0ZF5NV
+JN/9eaI5dWFOmxxi0IOPb6ODilMjquDmEOIycv4Sh+/Ij9fMgKKWP7IdlC5BOy8d
+w09WdrLqhOVcpJjcqb3z+xHHwyCNXxhhFomolPVzInyTPBSfDnH0nKIGQyvlhB0k
+TpGK61sjkfqS+xi59IxuklvHEsPr1WnTsaOhiXz7yPJZ+q3A1fhW0UkRZDYgZsEm
+/gNJ3rp8XYuDgki3gE+8IWAdAXq1yhjD7RJB8TSIa5tHjJQKjgCeHnGzAgMBAAGj
+azBpMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMB
+Af8EBTADAQH/MDEGA1UdEQQqMCiCCWxvY2FsaG9zdIIVbWluaW8tc2VydmljZS5k
+ZWZhdWx0hwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQCmFL39MHuY31a11Dj4p25c
+qPEC4DvIQj3NOdSGV2d+f6sgzFz1WL8VrqvB1B1S6r4Jb2PEuIBD84YpUrHORMSc
+wubLJiHKDkBfoe9Ab5p/UjJrKKnj34DlvsW/Gp0Y6XsPViWiUj+oRKmGVI24CBHv
+g+BmW3CyNQGTKj94xM6s3AWlGEoyaqWPe5xyeUe3f1AZF97tCjIJReVlCmhCF+Bm
+aTcTRQcwqWoCp0bbYpyDDYpRlq8GPlIE9o2Z6AsNfLrUpamgqX2kXkh1kysJQ+jP
+zQZtrR0mmtur3DnEm2bi4NKHAQHpW9Mu16GQjE1NbXqQtTB88jK76ctH934Cal6V
+-----END CERTIFICATE-----"
 
 # replica with 4MB backing file
 backing_file='backing_file.raw'
@@ -90,6 +109,41 @@ trap "kill $pid_ime && cleanupISCSI && kill $pid_imr" EXIT
 # start minio server to test s3 backup and set credential keys
 export MINIO_ACCESS_KEY=test-access-key
 export MINIO_SECRET_KEY=test-secret-key
+
+# create custom ssl test certs
+mkdir -p ~/.minio/certs
+echo "$AWS_CERT" > ~/.minio/certs/public.crt
+cat <<"EOT" > ~/.minio/certs/private.key
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDXzUurgPZDgzT3
+DYuaebgewqowdeAD84VYazfSuQ+7+mNkiiQPozUU2foQaF/PqzBbQmegoaOyy5Xj
+3UExmFretx0ZF5NVJN/9eaI5dWFOmxxi0IOPb6ODilMjquDmEOIycv4Sh+/Ij9fM
+gKKWP7IdlC5BOy8dw09WdrLqhOVcpJjcqb3z+xHHwyCNXxhhFomolPVzInyTPBSf
+DnH0nKIGQyvlhB0kTpGK61sjkfqS+xi59IxuklvHEsPr1WnTsaOhiXz7yPJZ+q3A
+1fhW0UkRZDYgZsEm/gNJ3rp8XYuDgki3gE+8IWAdAXq1yhjD7RJB8TSIa5tHjJQK
+jgCeHnGzAgMBAAECggEAfUrCXka3tCbff3irzvpQffuDmDM35tNiXh2SAZRUoE0V
+m+/gU/vr+7k6yH/w8L9xieqaA9cVFd/BnNR+326Xg6tJB6J6dfq82YvfNgECiALi
+jjSFzaeBhgOvlYvGm4y955CAFv45p3ZsUl11CEre/PFlkZXtGxikXYz4/9Q83nXY
+s6x7Oa82R7pOikihwCAoU57F78eaJ8mqNi0FQvlyqJOP11BmZxvnxeMuKjhB9ONp
+LSp1jsey9l6MGjUn0FLnwDvdUdb+FePI1N7VaCAwxI+rGkrSZHgzHVXOvUJN7kvA
+j5FO5on4h/+xWnF33yqgEoYft0QI/jWKcNWWukjBwQKBgQDeE6RFEJlOd5iW1ymj
+n9DCgs5EmqmEswYOynCwSda+YM6vUbiZsY8Yop1TfUcxqHv6APXjUwcAPmPTOJEo
+2RmKLSbHlNw8lSN1blX0D/s3jg5GueUogmnSVxLkHu8XJGJ7W1QxE3doHPtkq3ij
+hkOPNridS4Rlj52pbHlr5/C4cQKBgQD4xEbjnrMaxUvoLqU4oOlb9W9S+RRYSsG1
+lIRh376SWFnM9Rtj21243XdhN3PPmI3Mz+0b7r2vRR/K1/BsRTBykN/dnEn5U1BA
+botpfHKRosQTGXHBA/3Bk4/j9jeStfUx3glwyB4/hNG/J3VUWaWyDSFnjdQ/pblG
+zUilIPf+YwKBgQCp2GXbeI13yNpICzlKbjFQgpBVQeCCoBTy/PtgqKh3pDyPM7Y2
+vekOU1h2ASuRHCXtmAx3FwoUsqLQacQDdL8mwc+V9xDVuM6Mwp00c4CUBa5/gy9z
+YwKiH3xQQiRkE6zKYZgrjJLXassOPGKg1lAXWSerDZWtw0A20sKut46Q0QKBgHFe
+qdvUGFWr8oL2tw9OrerduIU8xFvUfeEttQMRv7zcDNjOH1RrxZOZQm2IovvJz122
+qJ1hOQrmWq3LqWL+SSz8/zj0n/XDVUB34IsLTv82CVuW7fODySJuCFZggEUZLYwz
+X2QJn1ddRWVzKxJs5Il3WHDj/wWelghBR8kRdFN3AoGAI6WCv2PCYTKVY6008V0n
+rL47a9Ojvtc/5KfqJ1i2JJMH2B/cmMVE+83gi81HSQj1a+6pczKfAZieg0FOg/My
+PzVVQbjJNv4C39+7qH85XgYMvaq2th1Dee/Csl2S8BUtqnfsEn1F0qheYBYodblp
+WtThNhF/hEXsnBQ9DrZBJOU=
+-----END PRIVATE KEY-----
+EOT
+
 # create default bucket
 mkdir -p /data/backupbucket
 # run minio server

--- a/vendor/github.com/longhorn/backupstore/.gitignore
+++ b/vendor/github.com/longhorn/backupstore/.gitignore
@@ -22,3 +22,11 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# build files
+/.dapper
+
+# ignores all goland project folders and files
+.idea/
+*.iml
+*.ipr

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -590,7 +590,7 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 
 	v, err := loadVolume(volumeName, bsDriver)
 	if err != nil {
-		return fmt.Errorf("Cannot find volume %v in backupstore", volumeName, err)
+		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
 	}
 
 	backup, err := loadBackup(backupName, volumeName, bsDriver)

--- a/vendor/github.com/longhorn/backupstore/driver.go
+++ b/vendor/github.com/longhorn/backupstore/driver.go
@@ -34,7 +34,7 @@ var (
 )
 
 func generateError(fields logrus.Fields, format string, v ...interface{}) error {
-	return ErrorWithFields("backupstore", fields, format, v)
+	return ErrorWithFields("backupstore", fields, format, v...)
 }
 
 func init() {

--- a/vendor/github.com/longhorn/backupstore/http/client.go
+++ b/vendor/github.com/longhorn/backupstore/http/client.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+)
+
+func getSystemCerts() *x509.CertPool {
+	certs, _ := x509.SystemCertPool()
+	if certs == nil {
+		certs = x509.NewCertPool()
+	}
+	return certs
+}
+
+// GetDefaultClient returns a client that does ssl verification based on the system certificates
+func GetDefaultClient() (*http.Client, error) {
+	return GetClient(false, nil)
+}
+
+func GetInsecureClient() (*http.Client, error) {
+	return GetClient(true, nil)
+}
+
+func GetClientWithCustomCerts(certs []byte) (*http.Client, error) {
+	return GetClient(true, certs)
+}
+
+func GetClient(insecure bool, customCerts []byte) (*http.Client, error) {
+	certs := getSystemCerts()
+
+	// CA's are base 64 encoded and appended together
+	// can contain root CAs, intermediate CAs and certificates
+	if ok := certs.AppendCertsFromPEM(customCerts); customCerts != nil && !ok {
+		return nil, fmt.Errorf("failed to append custom certificates: %v", string(customCerts))
+	}
+
+	// create custom http client that trusts our custom certs
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: insecure,
+		RootCAs:            certs,
+	}
+	client := &http.Client{Transport: customTransport}
+	return client, nil
+}

--- a/vendor/github.com/longhorn/backupstore/s3/s3_service.go
+++ b/vendor/github.com/longhorn/backupstore/s3/s3_service.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -14,6 +15,7 @@ import (
 type Service struct {
 	Region string
 	Bucket string
+	Client *http.Client
 }
 
 func (s *Service) New() (*s3.S3, error) {
@@ -24,7 +26,16 @@ func (s *Service) New() (*s3.S3, error) {
 		config.Endpoint = aws.String(endpoints)
 		config.S3ForcePathStyle = aws.Bool(true)
 	}
-	return s3.New(session.New(), config), nil
+
+	if s.Client != nil {
+		config.HTTPClient = s.Client
+	}
+
+	ses, err := session.NewSession(config)
+	if err != nil {
+		return nil, err
+	}
+	return s3.New(ses), nil
 }
 
 func (s *Service) Close() {

--- a/vendor/github.com/longhorn/backupstore/singlefile.go
+++ b/vendor/github.com/longhorn/backupstore/singlefile.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/longhorn/backupstore/util"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
 )
@@ -86,7 +86,7 @@ func RestoreSingleFileBackup(backupURL, path string) (string, error) {
 
 	if _, err := loadVolume(srcVolumeName, driver); err != nil {
 		return "", generateError(logrus.Fields{
-			LogFieldVolume:     srcVolumeName,
+			LogFieldVolume:    srcVolumeName,
 			LogEventBackupURL: backupURL,
 		}, "Volume doesn't exist in backupstore: %v", err)
 	}
@@ -117,7 +117,7 @@ func DeleteSingleFileBackup(backupURL string) error {
 
 	_, err = loadVolume(volumeName, driver)
 	if err != nil {
-		return fmt.Errorf("Cannot find volume %v in backupstore", volumeName, err)
+		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
 	}
 
 	backup, err := loadBackup(backupName, volumeName, driver)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,10 +62,11 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200410230022-28cbdac36bf4
+# github.com/longhorn/backupstore v0.0.0-20200428191103-882e4d6f20a5
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops
+github.com/longhorn/backupstore/http
 github.com/longhorn/backupstore/logging
 github.com/longhorn/backupstore/nfs
 github.com/longhorn/backupstore/s3


### PR DESCRIPTION
Depends on longhorn/backupstore#32 and requires an updated go module reference to be able to correctly build this.

This is to address longhorn/longhorn#704