### PR TITLE
Update longhorn/backupstore to v0.0.0-20200513030129-7f9a1e8a1d69

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405
+	github.com/longhorn/backupstore v0.0.0-20200513030129-7f9a1e8a1d69
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405 h1:RTgfE4mD8l4wyWROFPKMFQW72TYytVC9Q3ZF/N7yw6s=
-github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200513030129-7f9a1e8a1d69 h1:Bvla8OBnrAHqLkJrAHv5qo19hHw2hfJ4VW2dawHNE0U=
+github.com/longhorn/backupstore v0.0.0-20200513030129-7f9a1e8a1d69/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487 h1:ARgyOW/q9zb2MS5EEX3X9frQhBtpeSX4PVf9DJXTUy4=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200424013728-e7c199ecb487/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/vendor/github.com/longhorn/backupstore/http/client.go
+++ b/vendor/github.com/longhorn/backupstore/http/client.go
@@ -25,7 +25,7 @@ func GetInsecureClient() (*http.Client, error) {
 }
 
 func GetClientWithCustomCerts(certs []byte) (*http.Client, error) {
-	return GetClient(true, certs)
+	return GetClient(false, certs)
 }
 
 func GetClient(insecure bool, customCerts []byte) (*http.Client, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200509050526-150a317f1405
+# github.com/longhorn/backupstore v0.0.0-20200513030129-7f9a1e8a1d69
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
This is to fix the ssl certificate check for backups

https://github.com/longhorn/longhorn/issues/704

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
