### PR TITLE
Update backupstore for blk fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200530020211-e71b773c1805
+	github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200530020211-e71b773c1805 h1:Pwi54tMcKVUJbUl9smehb+lDEE1lj4rSFYFqmUDqsr0=
-github.com/longhorn/backupstore v0.0.0-20200530020211-e71b773c1805/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0 h1:Aw4gNAR+GF2oxluS02GcH8AuQYdmUEoh/dd2o63Nnfs=
+github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38 h1:Kzy8VxF0qiJ0CESA5CxzAGIRb5LVNa8LtfFKeVmmZD0=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/integration/common/cmd.py
+++ b/integration/common/cmd.py
@@ -87,9 +87,15 @@ def backup_status(url, backupID):
     return output
 
 
-def backup_create(url, snapshot, dest):
+def backup_create(url, snapshot, dest, labels=None):
     cmd = [_bin(), '--url', url, '--debug',
            'backup', 'create', snapshot, '--dest', dest]
+
+    if labels is not None:
+        for key in labels:
+            cmd.append('--label')
+            cmd.append(key + '=' + labels[key])
+
     backup = json.loads(subprocess.check_output(cmd, encoding='utf-8').strip())
     assert "backupID" in backup.keys()
     assert "isIncremental" in backup.keys()
@@ -117,9 +123,12 @@ def backup_volume_rm(url, name, dest):
     return subprocess.check_call(cmd)
 
 
-def backup_volume_list(url, name, dest):
+def backup_volume_list(url, name, dest, include_backup_details=False):
     cmd = [_bin(), '--url', url, '--debug', 'backup', 'ls',
-           '--volume', name, '--volume-only', dest]
+           '--volume', name]
+    if not include_backup_details:
+        cmd.append('--volume-only')
+    cmd.append(dest)
     return json.loads(subprocess.check_output(cmd, encoding='utf-8'))
 
 

--- a/integration/common/constants.py
+++ b/integration/common/constants.py
@@ -56,7 +56,6 @@ FIXED_REPLICA_PATH1 = '/tmp/replica_fixed_dir_1/'
 FIXED_REPLICA_PATH2 = '/tmp/replica_fixed_dir_2/'
 
 BACKUP_DIR = '/data/backupbucket'
-BACKUP_DEST = 'vfs://' + BACKUP_DIR
 
 BACKING_FILE = 'backing_file.raw'
 BACKING_FILE_QCOW = 'backing_file.qcow2'

--- a/integration/common/util.py
+++ b/integration/common/util.py
@@ -10,6 +10,22 @@ def _base():
     return os.path.dirname(__file__)
 
 
+# find the path of the first file
+def findfile(start, name):
+    for relpath, dirs, files in os.walk(start):
+        if name in files:
+            full_path = os.path.join(start, relpath, name)
+            return os.path.normpath(os.path.abspath(full_path))
+
+
+# find the path of the first dir
+def finddir(start, name):
+    for relpath, dirs, files in os.walk(start):
+        if name in dirs:
+            full_path = os.path.join(start, relpath, name)
+            return os.path.normpath(os.path.abspath(full_path))
+
+
 def read_file(file_path, offset, length):
     assert os.path.exists(file_path)
     f = open(file_path, 'r')

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -44,6 +44,10 @@ from common.constants import (
     REPLICA_NAME, REPLICA_2_NAME, ENGINE_NAME,
 )
 
+from common.util import (
+    finddir, findfile
+)
+
 from rpc.controller.controller_client import ControllerClient
 from rpc.replica.replica_client import ReplicaClient
 from rpc.instance_manager.process_manager_client import ProcessManagerClient
@@ -84,22 +88,6 @@ def bin():
     c = _file('bin/longhorn')
     assert os.path.exists(c)
     return c
-
-
-# find the path of the first file
-def findfile(start, name):
-    for relpath, dirs, files in os.walk(start):
-        if name in files:
-            full_path = os.path.join(start, relpath, name)
-            return os.path.normpath(os.path.abspath(full_path))
-
-
-# find the path of the first dir
-def finddir(start, name):
-    for relpath, dirs, files in os.walk(start):
-        if name in dirs:
-            full_path = os.path.join(start, relpath, name)
-            return os.path.normpath(os.path.abspath(full_path))
 
 
 def setup_module():
@@ -838,6 +826,7 @@ def backup_core(bin, engine_manager_client,  # NOQA
                      VOLUME_NAME, backup_target)
 
     assert os.path.exists(BACKUP_DIR)
+    assert not os.path.exists(volume_cfg_path)
 
     grpc_controller_client.volume_frontend_start(
             frontend=FRONTEND_TGT_BLOCKDEV)

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -149,7 +149,7 @@ mkdir -p /data/backupbucket
 # run minio server
 /usr/bin/minio server /data &
 
-export BACKUPTARGETS=s3://backupbucket@us-east-1/backupstore,vfs:///data/backupbucket
+export BACKUPTARGETS=s3://backupbucket@us-east-1/s3-test,vfs:///data/backupbucket
 
 cd integration
 find -depth -name __pycache__ -o -name "*.pyc" -exec rm -rf {} \;

--- a/vendor/github.com/longhorn/backupstore/backupstore.go
+++ b/vendor/github.com/longhorn/backupstore/backupstore.go
@@ -70,14 +70,9 @@ func removeVolume(volumeName string, driver BackupStoreDriver) error {
 		return fmt.Errorf("Invalid volume name %v", volumeName)
 	}
 
-	if !volumeExists(volumeName, driver) {
-		return fmt.Errorf("Volume %v doesn't exist in backupstore", volumeName)
-	}
-
 	volumeDir := getVolumePath(volumeName)
 	volumeBlocksDirectory := getBlockPath(volumeName)
 	volumeBackupsDirectory := getBackupPath(volumeName)
-
 	if err := driver.Remove(volumeBackupsDirectory); err != nil {
 		return fmt.Errorf("failed to remove all the backups for volume %v: %v", volumeName, err)
 	}

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -32,6 +32,24 @@ type BlockMapping struct {
 	BlockChecksum string
 }
 
+type BlockInfo struct {
+	checksum string
+	path     string
+	refcount int
+}
+
+func isBlockPresent(blk *BlockInfo) bool {
+	return blk != nil && blk.path != ""
+}
+
+func isBlockReferenced(blk *BlockInfo) bool {
+	return blk != nil && blk.refcount > 0
+}
+
+func isBlockSafeToDelete(blk *BlockInfo) bool {
+	return isBlockPresent(blk) && !isBlockReferenced(blk)
+}
+
 type backupRequest struct {
 	lastBackup *Backup
 }
@@ -73,6 +91,7 @@ const (
 	BLOCKS_DIRECTORY      = "blocks"
 	BLOCK_SEPARATE_LAYER1 = 2
 	BLOCK_SEPARATE_LAYER2 = 4
+	BLK_SUFFIX            = ".blk"
 
 	PROGRESS_PERCENTAGE_BACKUP_SNAPSHOT = 95
 	PROGRESS_PERCENTAGE_BACKUP_TOTAL    = 100
@@ -612,6 +631,38 @@ func DeleteBackupVolume(volumeName string, destURL string) error {
 	return nil
 }
 
+func getBlockInfoMap(backups []*Backup, volume string, driver BackupStoreDriver) (map[string]*BlockInfo, error) {
+	blockInfos := make(map[string]*BlockInfo)
+	blockNames, err := getBlockNamesForVolume(volume, driver)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range blockNames {
+		blockInfos[name] = &BlockInfo{
+			checksum: name,
+			path:     getBlockFilePath(volume, name),
+			refcount: 0,
+		}
+	}
+
+	for _, backup := range backups {
+		for _, block := range backup.Blocks {
+			info, known := blockInfos[block.BlockChecksum]
+			if !known {
+				log.Errorf("backup %v of volume %v refers to unknown block %v",
+					backup.Name, volume, block.BlockChecksum)
+				info = &BlockInfo{checksum: block.BlockChecksum}
+				blockInfos[block.BlockChecksum] = info
+			}
+
+			info.refcount += 1
+		}
+	}
+
+	return blockInfos, nil
+}
+
 func DeleteDeltaBlockBackup(backupURL string) error {
 	bsDriver, err := GetBackupStoreDriver(backupURL)
 	if err != nil {
@@ -623,55 +674,61 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 		return err
 	}
 
+	// If we fail to load the backup we still want to proceed with the deletion of the backup file
 	backupToBeDeleted, err := loadBackup(backupName, volumeName, bsDriver)
 	if err != nil {
-		return err
-	}
-	discardBlockSet := make(map[string]bool)
-	for _, blk := range backupToBeDeleted.Blocks {
-		discardBlockSet[blk.BlockChecksum] = true
+		log.Warnf("failed to load to be deleted backup %v for volume %v", backupName, volumeName)
+		backupToBeDeleted = &Backup{
+			Name:       backupName,
+			VolumeName: volumeName,
+		}
 	}
 
 	log.Debug("GC started")
+	var backupsToBeRetained []*Backup
+	deleteBlocks := true
 	backupNames, err := getBackupNamesForVolume(volumeName, bsDriver)
-	for i := 0; len(discardBlockSet) > 0 && i < len(backupNames); i++ {
-		backup, err := loadBackup(backupNames[i], volumeName, bsDriver)
+	if err != nil {
+		log.Warnf("skipping block deletion failed to load backup names for volume %v", volumeName)
+		deleteBlocks = false
+	}
+	backupNames = util.Filter(backupNames, func(name string) bool { return name != backupToBeDeleted.Name })
+	for _, name := range backupNames {
+		backup, err := loadBackup(name, volumeName, bsDriver)
 		if err != nil {
-			return err
+			log.Warnf("skipping block deletion because we failed to load backup %v for volume %v error %v",
+				name, volumeName, err)
+			deleteBlocks = false
+			break
 		}
 
 		if isBackupInProgress(backup) {
 			log.Infof("skipping block deletion because of in progress backup %v for volume %v",
 				backup.Name, volumeName)
-			discardBlockSet = make(map[string]bool)
+			deleteBlocks = false
 			break
 		}
 
-		if backup.Name == backupToBeDeleted.Name {
-			continue
-		}
-
-		for j := 0; len(discardBlockSet) > 0 && j < len(backup.Blocks); j++ {
-			blk := backup.Blocks[j]
-			if _, exists := discardBlockSet[blk.BlockChecksum]; exists {
-				delete(discardBlockSet, blk.BlockChecksum)
-			}
-		}
+		backupsToBeRetained = append(backupsToBeRetained, backup)
 	}
 
-	var blkFileList []string
-	for blk := range discardBlockSet {
-		blkFileList = append(blkFileList, getBlockFilePath(volumeName, blk))
-		log.Debugf("Found unused blocks %v for volume %v", blk, volumeName)
+	blockMap, err := getBlockInfoMap(backupsToBeRetained, volumeName, bsDriver)
+	if err != nil {
+		log.Warnf("skipping block deletion because we failed to get block infos for volume %v error %v",
+			volumeName, err)
+		deleteBlocks = false
 	}
 
 	// we can delete the requested backupToBeDeleted now
+	if err := removeBackup(backupToBeDeleted, bsDriver); err != nil {
+		return err
+	}
+	log.Infof("Removed backup %v for volume %v", backupName, volumeName)
+
+	// update the volume
 	v, err := loadVolume(volumeName, bsDriver)
 	if err != nil {
 		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
-	}
-	if err := removeBackup(backupToBeDeleted, bsDriver); err != nil {
-		return err
 	}
 	if backupToBeDeleted.Name == v.LastBackupName {
 		v.LastBackupName = ""
@@ -684,31 +741,83 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 	// check if there have been new backups created while we where processing
 	prevBackupNames := backupNames
 	backupNames, err = getBackupNamesForVolume(volumeName, bsDriver)
-	backupNames = append(backupNames, backupToBeDeleted.Name)
 	if err != nil || !util.UnorderedEqual(prevBackupNames, backupNames) {
 		log.Infof("Skipping block deletion because we found new backups for volume %v", volumeName)
-		return nil
+		deleteBlocks = false
 	}
-	if err := bsDriver.Remove(blkFileList...); err != nil {
-		return err
-	}
-	log.Debug("Removed unused blocks for volume ", volumeName)
 
+	// only delete the blocks if it is safe to do so
+	if deleteBlocks {
+		if err := cleanupBlocks(blockMap, volumeName, bsDriver); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupBlocks(blockMap map[string]*BlockInfo, volume string, driver BackupStoreDriver) error {
+	var deletionFailures []string
+	activeBlockCount := int64(0)
+	deletedBlockCount := int64(0)
+	for _, blk := range blockMap {
+		if isBlockSafeToDelete(blk) {
+			if err := driver.Remove(blk.path); err != nil {
+				deletionFailures = append(deletionFailures, blk.checksum)
+				continue
+			}
+			log.Debugf("deleted block %v for volume %v", blk.checksum, volume)
+			deletedBlockCount++
+		} else if isBlockReferenced(blk) && isBlockPresent(blk) {
+			activeBlockCount++
+		}
+	}
+
+	if len(deletionFailures) > 0 {
+		return fmt.Errorf("failed to delete backup blocks: %v", deletionFailures)
+	}
+
+	log.Debugf("Retained %v blocks for volume %v", activeBlockCount, volume)
+	log.Debugf("Removed %v unused blocks for volume %v", deletedBlockCount, volume)
 	log.Debug("GC completed")
-	log.Debug("Removed backupstore backupToBeDeleted ", backupName)
 
-	v, err = loadVolume(volumeName, bsDriver)
+	v, err := loadVolume(volume, driver)
 	if err != nil {
 		return err
 	}
 
-	v.BlockCount -= int64(len(discardBlockSet))
-
-	if err := saveVolume(v, bsDriver); err != nil {
+	// update the block count to what we actually have on disk that is in use
+	v.BlockCount = activeBlockCount
+	if err := saveVolume(v, driver); err != nil {
 		return err
 	}
-
 	return nil
+}
+
+func getBlockNamesForVolume(volumeName string, driver BackupStoreDriver) ([]string, error) {
+	names := []string{}
+	blockPathBase := getBlockPath(volumeName)
+	lv1Dirs, err := driver.List(blockPathBase)
+	// Directory doesn't exist
+	if err != nil {
+		return names, nil
+	}
+	for _, lv1 := range lv1Dirs {
+		lv1Path := filepath.Join(blockPathBase, lv1)
+		lv2Dirs, err := driver.List(lv1Path)
+		if err != nil {
+			return nil, err
+		}
+		for _, lv2 := range lv2Dirs {
+			lv2Path := filepath.Join(lv1Path, lv2)
+			blockNames, err := driver.List(lv2Path)
+			if err != nil {
+				return nil, err
+			}
+			names = append(names, blockNames...)
+		}
+	}
+
+	return util.ExtractNames(names, "", BLK_SUFFIX)
 }
 
 func getBlockPath(volumeName string) string {
@@ -719,7 +828,7 @@ func getBlockFilePath(volumeName, checksum string) string {
 	blockSubDirLayer1 := checksum[0:BLOCK_SEPARATE_LAYER1]
 	blockSubDirLayer2 := checksum[BLOCK_SEPARATE_LAYER1:BLOCK_SEPARATE_LAYER2]
 	path := filepath.Join(getBlockPath(volumeName), blockSubDirLayer1, blockSubDirLayer2)
-	fileName := checksum + ".blk"
+	fileName := checksum + BLK_SUFFIX
 
 	return filepath.Join(path, fileName)
 }

--- a/vendor/github.com/longhorn/backupstore/driver.go
+++ b/vendor/github.com/longhorn/backupstore/driver.go
@@ -17,7 +17,7 @@ type BackupStoreDriver interface {
 	GetURL() string
 	FileExists(filePath string) bool
 	FileSize(filePath string) int64
-	Remove(names ...string) error           // Bahavior like "rm -rf"
+	Remove(path string) error               // Bahavior like "rm -rf"
 	Read(src string) (io.ReadCloser, error) // Caller needs to close
 	Write(dst string, rs io.ReadSeeker) error
 	List(path string) ([]string, error) // Behavior like "ls", not like "find"

--- a/vendor/github.com/longhorn/backupstore/s3/s3.go
+++ b/vendor/github.com/longhorn/backupstore/s3/s3.go
@@ -155,15 +155,8 @@ func (s *BackupStoreDriver) FileSize(filePath string) int64 {
 	return *head.ContentLength
 }
 
-func (s *BackupStoreDriver) Remove(names ...string) error {
-	if len(names) == 0 {
-		return nil
-	}
-	paths := make([]string, len(names))
-	for i, name := range names {
-		paths[i] = s.updatePath(name)
-	}
-	return s.service.DeleteObjects(paths)
+func (s *BackupStoreDriver) Remove(path string) error {
+	return s.service.DeleteObjects(s.updatePath(path))
 }
 
 func (s *BackupStoreDriver) Read(src string) (io.ReadCloser, error) {

--- a/vendor/github.com/longhorn/backupstore/util/util.go
+++ b/vendor/github.com/longhorn/backupstore/util/util.go
@@ -86,6 +86,16 @@ func UnorderedEqual(x, y []string) bool {
 	return true
 }
 
+func Filter(elements []string, predicate func(string) bool) []string {
+	var filtered []string
+	for _, elem := range elements {
+		if predicate(elem) {
+			filtered = append(filtered, elem)
+		}
+	}
+	return filtered
+}
+
 func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
 	result := []string{}
 	for i := range names {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200530020211-e71b773c1805
+# github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
Integration tests for the backup delete changes.

We now have a test that verifies the correct gc operation for out of
order deletes and dependent blocks. We also now have a test that makes
sure that blocks are not deleted while there is an in progress backup.

longhorn/longhorn#1431 
longhorn/longhorn#1433 

With the orphaned block deletion in place we can now remove corrupted
backup.cfg files, since that will just orphan the blocks and they will
be cleaned up with all the other orphaned blocks.
With the removal of the volume.cfg existence check we can now also
cleanup a volume folder including all subfolders when requested via a
backup volume removal.

longhorn/longhorn#1213

depends on longhorn/backupstore#41
