### PR TITLE
Add test for backup volume list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0
+	github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0 h1:Aw4gNAR+GF2oxluS02GcH8AuQYdmUEoh/dd2o63Nnfs=
-github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833 h1:CPMhBEV3fHr2UutWQ1wt/n4rl0XV5+IVqnOIcIkqTcI=
+github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38 h1:Kzy8VxF0qiJ0CESA5CxzAGIRb5LVNa8LtfFKeVmmZD0=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/integration/common/constants.py
+++ b/integration/common/constants.py
@@ -34,10 +34,12 @@ PAGE_SIZE = 512
 TEST_PREFIX = dict(os.environ)["TESTPREFIX"]
 
 VOLUME_NAME = TEST_PREFIX + "volume"
+VOLUME2_NAME = TEST_PREFIX + "volume-2"
 VOLUME_BACKING_NAME = TEST_PREFIX + 'volume-backing'
 VOLUME_NO_FRONTEND_NAME = TEST_PREFIX + 'volume-no-frontend'
 
 ENGINE_NAME = TEST_PREFIX + "engine"
+ENGINE2_NAME = TEST_PREFIX + "engine-2"
 ENGINE_BACKING_NAME = TEST_PREFIX + 'engine-backing'
 ENGINE_NO_FRONTEND_NAME = TEST_PREFIX + 'engine-no-frontend'
 

--- a/vendor/github.com/longhorn/backupstore/config.go
+++ b/vendor/github.com/longhorn/backupstore/config.go
@@ -88,7 +88,7 @@ func getVolumePath(volumeName string) string {
 	checksum := util.GetChecksum([]byte(volumeName))
 	volumeLayer1 := checksum[0:VOLUME_SEPARATE_LAYER1]
 	volumeLayer2 := checksum[VOLUME_SEPARATE_LAYER1:VOLUME_SEPARATE_LAYER2]
-	return filepath.Join(backupstoreBase, VOLUME_DIRECTORY, volumeLayer1, volumeLayer2, volumeName)
+	return filepath.Join(backupstoreBase, VOLUME_DIRECTORY, volumeLayer1, volumeLayer2, volumeName) + "/"
 }
 
 func getVolumeFilePath(volumeName string) string {

--- a/vendor/github.com/longhorn/backupstore/list.go
+++ b/vendor/github.com/longhorn/backupstore/list.go
@@ -47,11 +47,6 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 		return nil, fmt.Errorf("Invalid volume name %v", volumeName)
 	}
 
-	backupNames, err := getBackupNamesForVolume(volumeName, driver)
-	if err != nil {
-		return nil, err
-	}
-
 	volume, err := loadVolume(volumeName, driver)
 	if err != nil {
 		return &VolumeInfo{
@@ -63,6 +58,13 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 
 	volumeInfo := fillVolumeInfo(volume)
 	if volumeOnly {
+		return volumeInfo, nil
+	}
+
+	// try to find all backups for this volume
+	backupNames, err := getBackupNamesForVolume(volumeName, driver)
+	if err != nil {
+		volumeInfo.Messages[MessageTypeError] = err.Error()
 		return volumeInfo, nil
 	}
 
@@ -129,9 +131,10 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 func failedBackupInfo(backupName string, volumeName string,
 	destURL string, err error) *BackupInfo {
 	return &BackupInfo{
-		Name:     backupName,
-		URL:      encodeBackupURL(backupName, volumeName, destURL),
-		Messages: map[MessageType]string{MessageTypeError: err.Error()},
+		Name:       backupName,
+		URL:        encodeBackupURL(backupName, volumeName, destURL),
+		VolumeName: volumeName,
+		Messages:   map[MessageType]string{MessageTypeError: err.Error()},
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200604011416-823dc44a33c0
+# github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
The test makes sure that if there is failure when trying to retrieve the
backup names for that volume, that the list operation does not fail.
Since a failure would block the list operation of returning information
for all the other backup volumes. Instead of failing the whole operation
we add a Error message to the backup volume.

longhorn/longhorn#1410

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
