### PR TITLE
Restore Rafactoring

### DIFF
--- a/app/cmd/backup.go
+++ b/app/cmd/backup.go
@@ -222,6 +222,12 @@ func BackupRestoreCmd() cli.Command {
 		},
 		Action: func(c *cli.Context) {
 			if err := restoreBackup(c); err != nil {
+				errInfo, jsonErr := json.MarshalIndent(err, "", "\t")
+				if jsonErr != nil {
+					logrus.Errorf("Cannot marshal err [%v] to json: %v", err, jsonErr)
+				} else {
+					fmt.Println(string(errInfo))
+				}
 				logrus.Fatalf("Error running restore backup command: %v", err)
 			}
 		},
@@ -336,7 +342,6 @@ func doRestoreBackupIncrementally(c *cli.Context) error {
 	lastRestored := c.String("last-restored")
 
 	if err := task.RestoreBackupIncrementally(backupURL, backupName, lastRestored, credential); err != nil {
-		logrus.Errorf("failed to perform incremental restore: %v", err)
 		return err
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973
+	github.com/longhorn/backupstore v0.0.0-20200612163229-31a628633b8f
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973 h1:aCCuo3CjF1nSpd48gmKp5dCiz9CjCJRaFZo2RpK7QdI=
-github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200612163229-31a628633b8f h1:/CwYtCWykygXbhzcTEBBUPsJxuotbC66UEWq7xZqW5Y=
+github.com/longhorn/backupstore v0.0.0-20200612163229-31a628633b8f/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38 h1:Kzy8VxF0qiJ0CESA5CxzAGIRb5LVNa8LtfFKeVmmZD0=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/pkg/backup/main.go
+++ b/pkg/backup/main.go
@@ -128,15 +128,7 @@ func DoBackupCreate(volumeName string, snapshotName string, destURL string,
 }
 
 func DoBackupRestore(backupURL string, toFile string, restoreObj *replica.RestoreStatus) error {
-	if backupURL == "" {
-		return RequiredMissingError("backup URL")
-	}
 	backupURL = util.UnescapeURL(backupURL)
-
-	if toFile == "" {
-		return RequiredMissingError("snapshot")
-	}
-
 	log.Debugf("Start restoring from %v into snapshot %v", backupURL, toFile)
 
 	config := &backupstore.DeltaRestoreConfig{
@@ -154,27 +146,8 @@ func DoBackupRestore(backupURL string, toFile string, restoreObj *replica.Restor
 
 func DoBackupRestoreIncrementally(url string, deltaFile string, lastRestored string,
 	restoreObj *replica.RestoreStatus) error {
-	if url == "" {
-		return RequiredMissingError("backup URL")
-	}
 	backupURL := util.UnescapeURL(url)
-
-	if deltaFile == "" {
-		return RequiredMissingError("delta file")
-	}
-
-	if lastRestored == "" {
-		return RequiredMissingError("last-restored")
-	}
-
-	// check delta file
-	if _, err := os.Stat(deltaFile); err == nil {
-		logrus.Warnf("delta file %s for incremental restoring exists, will remove and re-create it", deltaFile)
-		err = os.Remove(deltaFile)
-		if err != nil {
-			return err
-		}
-	}
+	log.Debugf("Start incremental restoring from %v into delta file %v", backupURL, deltaFile)
 
 	config := &backupstore.DeltaRestoreConfig{
 		BackupURL:      backupURL,

--- a/pkg/replica/backup.go
+++ b/pkg/replica/backup.go
@@ -59,7 +59,11 @@ func (rr *RestoreStatus) UpdateRestoreStatus(snapshot string, rp int, re error) 
 	rr.SnapshotName = snapshot
 	rr.Progress = rp
 	if re != nil {
-		rr.Error = re.Error()
+		if rr.Error != "" {
+			rr.Error = fmt.Sprintf("%v: %v", re.Error(), rr.Error)
+		} else {
+			rr.Error = re.Error()
+		}
 		rr.State = ProgressStateError
 	}
 }
@@ -67,7 +71,9 @@ func (rr *RestoreStatus) UpdateRestoreStatus(snapshot string, rp int, re error) 
 func (rr *RestoreStatus) FinishRestore() {
 	rr.Lock()
 	defer rr.Unlock()
-	rr.State = ProgressStateComplete
+	if rr.State != ProgressStateError {
+		rr.State = ProgressStateComplete
+	}
 }
 
 type BackupStatus struct {

--- a/pkg/replica/backup.go
+++ b/pkg/replica/backup.go
@@ -31,7 +31,7 @@ type DeltaBlockBackupOperations interface {
 */
 
 type RestoreStatus struct {
-	sync.Mutex
+	sync.RWMutex
 	replicaAddress string
 	SnapshotName   string //This will be deltaFileName in case of Incremental Restore
 	Progress       int
@@ -73,6 +73,19 @@ func (rr *RestoreStatus) FinishRestore() {
 	defer rr.Unlock()
 	if rr.State != ProgressStateError {
 		rr.State = ProgressStateComplete
+	}
+}
+
+func (rr *RestoreStatus) DeepCopy() *RestoreStatus {
+	rr.RLock()
+	defer rr.RUnlock()
+	return &RestoreStatus{
+		SnapshotName:     rr.SnapshotName,
+		Progress:         rr.Progress,
+		Error:            rr.Error,
+		LastRestored:     rr.LastRestored,
+		SnapshotDiskName: rr.SnapshotDiskName,
+		BackupURL:        rr.BackupURL,
 	}
 }
 

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -47,7 +47,7 @@ const (
 )
 
 type SyncAgentServer struct {
-	sync.Mutex
+	sync.RWMutex
 
 	currentPort     int
 	startPort       int
@@ -172,14 +172,14 @@ func (s *SyncAgentServer) nextPort(processName string) (int, error) {
 }
 
 func (s *SyncAgentServer) IsRestoring() bool {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 	return s.isRestoring
 }
 
 func (s *SyncAgentServer) GetLastRestored() string {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 	return s.lastRestored
 }
 
@@ -406,8 +406,8 @@ func (s *SyncAgentServer) FinishRebuild() error {
 }
 
 func (s *SyncAgentServer) IsRebuilding() bool {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	return s.isRebuilding
 }
@@ -1061,8 +1061,8 @@ func (s *SyncAgentServer) FinishPurge() error {
 }
 
 func (s *SyncAgentServer) IsPurging() bool {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	return s.isPurging
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973
+# github.com/longhorn/backupstore v0.0.0-20200612163229-31a628633b8f
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1188

Summary:
1. Refactor the implementation of restore:
    1. Check the parameters.
    2. Prepare to restore: Initiate the restore status and set the fields. Then all restore errors after the preparation will be recorded in the restore status.
    3. Start to restore: prepare the restore file and start to fetch inf/data from the backupstore.
    4. Finish restore: wait for the restore complete, reload/revert the snapshot, use a defer function to update the restore status and the fields.
2. Format the restore errors for replica syne agent servers and return 
3. Update the integration test: Test the error during the starting stage will be recorded in the restore status; check the error from sync agent servers are formated and printed.
