### PR TITLE
Backup list operation should ignore badly named files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833
+	github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833 h1:CPMhBEV3fHr2UutWQ1wt/n4rl0XV5+IVqnOIcIkqTcI=
-github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
+github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973 h1:aCCuo3CjF1nSpd48gmKp5dCiz9CjCJRaFZo2RpK7QdI=
+github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973/go.mod h1:TEcXB6izcrf4DMxnAhEKasrrmRq0nK4wlTUVrDIZaYg=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38 h1:Kzy8VxF0qiJ0CESA5CxzAGIRb5LVNa8LtfFKeVmmZD0=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/vendor/github.com/longhorn/backupstore/config.go
+++ b/vendor/github.com/longhorn/backupstore/config.go
@@ -148,7 +148,7 @@ func getBackupNamesForVolume(volumeName string, driver BackupStoreDriver) ([]str
 		// path doesn't exist
 		return result, nil
 	}
-	return util.ExtractNames(fileList, BACKUP_CONFIG_PREFIX, CFG_SUFFIX)
+	return util.ExtractNames(fileList, BACKUP_CONFIG_PREFIX, CFG_SUFFIX), nil
 }
 
 func getBackupPath(volumeName string) string {

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -817,7 +817,7 @@ func getBlockNamesForVolume(volumeName string, driver BackupStoreDriver) ([]stri
 		}
 	}
 
-	return util.ExtractNames(names, "", BLK_SUFFIX)
+	return util.ExtractNames(names, "", BLK_SUFFIX), nil
 }
 
 func getBlockPath(volumeName string) string {

--- a/vendor/github.com/longhorn/backupstore/util/util.go
+++ b/vendor/github.com/longhorn/backupstore/util/util.go
@@ -96,14 +96,13 @@ func Filter(elements []string, predicate func(string) bool) []string {
 	return filtered
 }
 
-func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
+func ExtractNames(names []string, prefix, suffix string) []string {
 	result := []string{}
-	for i := range names {
-		f := names[i]
+	for _, f := range names {
 		// Remove additional slash if exists
 		f = strings.TrimLeft(f, "/")
 
-		// Not a backup config file
+		// missing prefix or suffix
 		if !strings.HasPrefix(f, prefix) || !strings.HasSuffix(f, suffix) {
 			continue
 		}
@@ -111,11 +110,13 @@ func ExtractNames(names []string, prefix, suffix string) ([]string, error) {
 		f = strings.TrimPrefix(f, prefix)
 		f = strings.TrimSuffix(f, suffix)
 		if !ValidateName(f) {
-			return nil, fmt.Errorf("Invalid name %v was processed to extract name with prefix %v surfix %v", names[i], prefix, suffix)
+			logrus.Errorf("Invalid name %v was processed to extract name with prefix %v suffix %v",
+				f, prefix, suffix)
+			continue
 		}
 		result = append(result, f)
 	}
-	return result, nil
+	return result
 }
 
 func ValidateName(name string) bool {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200604031945-5030ff45d833
+# github.com/longhorn/backupstore v0.0.0-20200611170443-441b1cd8f973
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
We should ignore badly named files instead of erroring, since the files don't match our search pattern we don't need to concern ourselves with them (we filter them out)

depends on longhorn/backupstore#42
longhorn/longhorn#1410