### PR TITLE
Update backupstore to v0.0.0-20200709195833-7392333d6d22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20200709175939-de8e773a2a9d
+	github.com/longhorn/backupstore v0.0.0-20200709195833-7392333d6d22
 	github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38
 	github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20200709175939-de8e773a2a9d h1:owLmZSfZ7RuGx4e6Hll6bF86fLtwWImZNfDr4KNOClc=
-github.com/longhorn/backupstore v0.0.0-20200709175939-de8e773a2a9d/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
+github.com/longhorn/backupstore v0.0.0-20200709195833-7392333d6d22 h1:YcPn0DZf5cQJrVRJeXkyjkhvcREjHxIdWzxFKy2I+Wc=
+github.com/longhorn/backupstore v0.0.0-20200709195833-7392333d6d22/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38 h1:Kzy8VxF0qiJ0CESA5CxzAGIRb5LVNa8LtfFKeVmmZD0=
 github.com/longhorn/go-iscsi-helper v0.0.0-20200601183015-ca8b762c2f38/go.mod h1:3RTrAwLd6uaku/4wPE0KkSQI2OmhPgGO1SQ2Hbix5hY=
 github.com/longhorn/sparse-tools v0.0.0-20191231185723-50ffab4d4329 h1:fE6vFueGtkftPlZK85U8dGyoQoSE4/nRRBkOa5I0WFk=

--- a/integration/data/test_backup.py
+++ b/integration/data/test_backup.py
@@ -831,6 +831,11 @@ def test_backup_type(grpc_replica1, grpc_replica2,      # NOQA
         snap3 = cmd.snapshot_create(address)
         backup3 = create_backup(address, snap3, backup_target)
         backup3_url = backup3["URL"]
+        assert backup3['IsIncremental'] is True
+
+        # full backup: backup the same snapshot twice
+        backup3 = create_backup(address, snap3, backup_target)
+        backup3_url = backup3["URL"]
         assert backup3['IsIncremental'] is False
 
         # backup4: 256 random data in 1st block

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -667,6 +668,39 @@ func getBlockInfoMap(backups []*Backup, volume string, driver BackupStoreDriver)
 	return blockInfos, nil
 }
 
+// This function will get the last backup from the remaining backups
+func GetLatestBackup(backupsToBeRetained []*Backup, vol *Volume) error {
+	var lastBackupName string
+	var lastBackupAt string
+
+	for _, backup := range backupsToBeRetained {
+		if lastBackupName == "" || lastBackupAt == "" {
+			lastBackupName = backup.Name
+			lastBackupAt = backup.SnapshotCreatedAt
+		}
+
+		backupTime, err := time.Parse(time.RFC3339, backup.SnapshotCreatedAt)
+		if err != nil {
+			return fmt.Errorf("Cannot parse backup %v time %v due to %v", backup.Name, backup.SnapshotCreatedAt, err)
+		}
+
+		lastBackupTime, err := time.Parse(time.RFC3339, lastBackupAt)
+		if err != nil {
+			return fmt.Errorf("Cannot parse  last backup %v time %v due to %v", lastBackupName, lastBackupAt, err)
+		}
+
+		if backupTime.After(lastBackupTime) {
+			lastBackupName = backup.Name
+			lastBackupAt = backup.SnapshotCreatedAt
+		}
+	}
+
+	vol.LastBackupName = lastBackupName
+	vol.LastBackupAt = lastBackupAt
+
+	return nil
+}
+
 func DeleteDeltaBlockBackup(backupURL string) error {
 	bsDriver, err := GetBackupStoreDriver(backupURL)
 	if err != nil {
@@ -694,20 +728,6 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 	}
 	log.Infof("Removed backup %v for volume %v", backupName, volumeName)
 
-	// update the volume
-	v, err := loadVolume(volumeName, bsDriver)
-	if err != nil {
-		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
-	}
-
-	if backupToBeDeleted.Name == v.LastBackupName {
-		v.LastBackupName = ""
-		v.LastBackupAt = ""
-		if err := saveVolume(v, bsDriver); err != nil {
-			return err
-		}
-	}
-
 	log.Debug("GC started")
 	var backupsToBeRetained []*Backup
 	deleteBlocks := true
@@ -734,6 +754,24 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 		}
 
 		backupsToBeRetained = append(backupsToBeRetained, backup)
+	}
+
+	// update the volume
+	v, err := loadVolume(volumeName, bsDriver)
+	if err != nil {
+		return fmt.Errorf("Cannot find volume %v in backupstore due to: %v", volumeName, err)
+	}
+
+	if backupToBeDeleted.Name == v.LastBackupName {
+		v.LastBackupName = ""
+		v.LastBackupAt = ""
+		err := GetLatestBackup(backupsToBeRetained, v)
+		if err != nil {
+			return fmt.Errorf("Failed to get last backup creation time due to %v", err)
+		}
+		if err := saveVolume(v, bsDriver); err != nil {
+			return err
+		}
 	}
 
 	blockMap, err := getBlockInfoMap(backupsToBeRetained, volumeName, bsDriver)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20200709175939-de8e773a2a9d
+# github.com/longhorn/backupstore v0.0.0-20200709195833-7392333d6d22
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
Update backupstore to v0.0.0-20200709195833-7392333d6d22 for fixing the
LastBackup fields in volume.cfg when deleting the latest backup

https://github.com/longhorn/longhorn/issues/1381

Signed-off-by: Bo Tao <bo.tao@rancher.com>