### PR TITLE
pkg/sync/rpc, pkg/types, pkg/util: add HTTP_PROXY, HTTPS_PROXY, and N…

### DIFF
--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -439,6 +439,9 @@ func (s *SyncAgentServer) BackupCreate(ctx context.Context, req *ptypes.BackupCr
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+			os.Setenv(types.HTTPSProxy, credential[types.HTTPSProxy])
+			os.Setenv(types.HTTPProxy, credential[types.HTTPProxy])
+			os.Setenv(types.NOProxy, credential[types.NOProxy])
 
 			// set a custom ca cert if available
 			if credential[types.AWSCert] != "" {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,6 +23,10 @@ const (
 	AWSEndPoint  = "AWS_ENDPOINTS"
 	AWSCert      = "AWS_CERT"
 
+	HTTPSProxy = "HTTPS_PROXY"
+	HTTPProxy  = "HTTP_PROXY"
+	NOProxy    = "NO_PROXY"
+
 	RetryCounts   = 30
 	RetryInterval = 1 * time.Second
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -271,6 +271,9 @@ func GetBackupCredential(backupURL string) (map[string]string, error) {
 		credential[types.AWSSecretKey] = secretKey
 		credential[types.AWSEndPoint] = os.Getenv(types.AWSEndPoint)
 		credential[types.AWSCert] = os.Getenv(types.AWSCert)
+		credential[types.HTTPSProxy] = os.Getenv(types.HTTPSProxy)
+		credential[types.HTTPProxy] = os.Getenv(types.HTTPProxy)
+		credential[types.NOProxy] = os.Getenv(types.NOProxy)
 	}
 	return credential, nil
 }


### PR DESCRIPTION
…O_PROXY field to s3-secret. We use those infomation to setup http_proxy in Longhorn manager and engine

This fix is needed for users who are running a cluster behind a http_proxy and wish to use AWS S3 as the backupstore. First, we add 3 new fields in s3-secret (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY) to get the information about the http_proxy from user. Then we use the information to setup environment variables in Longhorn manager and engine. This will allow the manager and engine to send the outbound traffic to AWS S3 backupstore through the Http Proxy.

longhorn/longhorn#1540