### PR TITLE
 pkg/sync/rpc: set evirontment variables HTTP_PROXY, HTTPS_PROXY, and NO_PROXY so that engine use the http proxy when doing backup restore.

### DIFF
--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -564,6 +564,9 @@ func (s *SyncAgentServer) BackupRestore(ctx context.Context, req *ptypes.BackupR
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+			os.Setenv(types.HTTPSProxy, credential[types.HTTPSProxy])
+			os.Setenv(types.HTTPProxy, credential[types.HTTPProxy])
+			os.Setenv(types.NOProxy, credential[types.NOProxy])
 
 			// set a custom ca cert if available
 			if credential[types.AWSCert] != "" {
@@ -734,6 +737,9 @@ func (s *SyncAgentServer) BackupRestoreIncrementally(ctx context.Context,
 			os.Setenv(types.AWSAccessKey, credential[types.AWSAccessKey])
 			os.Setenv(types.AWSSecretKey, credential[types.AWSSecretKey])
 			os.Setenv(types.AWSEndPoint, credential[types.AWSEndPoint])
+			os.Setenv(types.HTTPSProxy, credential[types.HTTPSProxy])
+			os.Setenv(types.HTTPProxy, credential[types.HTTPProxy])
+			os.Setenv(types.NOProxy, credential[types.NOProxy])
 
 			// set a custom ca cert if available
 			if credential[types.AWSCert] != "" {


### PR DESCRIPTION
This fix is needed for users who are running a cluster behind a http_proxy and wish to use AWS S3 as the backupstore.

We set the environment variables before doing `BackupRestoreIncrementally` or `BackupRestore` so that Engine can use the http proxy and go out when doing backup restore.

longhorn/longhorn#1540