### PR TITLE
replica: Fix when replica crashed or removed triggers replica rebuild

### DIFF
--- a/integration/common/core.py
+++ b/integration/common/core.py
@@ -441,6 +441,25 @@ def verify_replica_state(grpc_c, addr, state):
     assert verified
 
 
+def verify_replica_mode(grpc_c, addr, mode):
+    if not addr.startswith("tcp://"):
+        addr = "tcp://" + addr
+
+    verified = False
+    for i in range(RETRY_COUNTS_SHORT):
+        replicas = grpc_c.replica_list()
+        snapList = cmd.snapshot_ls(grpc_c.address)
+        for r in replicas:
+            if r.address == addr and r.mode == mode:
+                verified = True
+                break
+        if verified:
+            break
+
+        time.sleep(RETRY_INTERVAL_SHORT)
+    assert verified
+
+
 def verify_read(dev, offset, data):
     for i in range(10):
         readed = read_dev(dev, offset, len(data))

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -74,6 +74,7 @@ type Info struct {
 	Head            string
 	Dirty           bool
 	Rebuilding      bool
+	Error           string
 	Parent          string
 	SectorSize      int64
 	BackingFileName string
@@ -1118,5 +1119,13 @@ func (r *Replica) GetRemainSnapshotCounts() int {
 }
 
 func (r *Replica) getDiskSize(disk string) int64 {
-	return util.GetFileActualSize(r.diskPath(disk))
+	ret := util.GetFileActualSize(r.diskPath(disk))
+	if ret == -1 {
+		errMessage := fmt.Sprintf("Fail to getfile %v size", r.diskPath(disk))
+		if r.info.Error == "" {
+			r.info.Error = errMessage
+			logrus.Error(errMessage)
+		}
+	}
+	return ret
 }

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -123,6 +123,8 @@ func (s *Server) Status() (State, Info) {
 	}
 	info := s.r.Info()
 	switch {
+	case info.Error != "":
+		return Error, info
 	case info.Rebuilding:
 		return Rebuilding, info
 	case info.Dirty:
@@ -310,7 +312,10 @@ func (s *Server) SetRevisionCounter(counter int64) error {
 }
 
 func (s *Server) PingResponse() error {
-	state, _ := s.Status()
+	state, info := s.Status()
+	if state == Error {
+		return fmt.Errorf("ping failure due to %v", info.Error)
+	}
 	if state != Open && state != Dirty && state != Rebuilding {
 		return fmt.Errorf("ping failure: replica state %v", state)
 	}


### PR DESCRIPTION
This fix adds the replica to report self detected errors through ping
response. And this will trigger replica rebuild automatically.

https://github.com/longhorn/longhorn/issues/1615

Signed-off-by: Bo Tao <bo.tao@rancher.com>