### PR TITLE
add command line argument directio (#1943)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/longhorn/backupstore v0.0.0-20210315131747-51dcc71901ed
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
-	github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408
+	github.com/longhorn/sparse-tools v0.0.0-20210322065822-14ef01cc10e9
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-runewidth v0.0.5-0.20181218000649-703b5e6b11ae // indirect
 	github.com/moby/moby v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b h1:RJukKq
 github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
-github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408 h1:buF1O/6By6sR6lZODDPzl12svm/Yq63FI81hKw9piTk=
-github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408/go.mod h1:1WSSJRDNret4VKADAzvD49oaVt1/idYVWBL8TiyevRk=
+github.com/longhorn/sparse-tools v0.0.0-20210322065822-14ef01cc10e9 h1:xz82ZNJhls2oZ8/Dwctgz2AQbAVMnG1LAYGymu1SX4A=
+github.com/longhorn/sparse-tools v0.0.0-20210322065822-14ef01cc10e9/go.mod h1:1WSSJRDNret4VKADAzvD49oaVt1/idYVWBL8TiyevRk=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
@@ -74,7 +74,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -329,8 +330,12 @@ func (*SyncAgentServer) FileRename(ctx context.Context, req *ptypes.FileRenameRe
 
 func (s *SyncAgentServer) FileSend(ctx context.Context, req *ptypes.FileSendRequest) (*empty.Empty, error) {
 	address := net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
+	directIO := true
+	if filepath.Ext(strings.TrimSpace(req.FromFileName)) == ".meta" {
+		directIO = false
+	}
 	logrus.Infof("Sending file %v to %v", req.FromFileName, address)
-	if err := sparse.SyncFile(req.FromFileName, address, FileSyncTimeout); err != nil {
+	if err := sparse.SyncFile(req.FromFileName, address, FileSyncTimeout, directIO); err != nil {
 		return nil, err
 	}
 	logrus.Infof("Done sending file %v to %v", req.FromFileName, address)

--- a/vendor/github.com/longhorn/sparse-tools/cli/ssync/main.go
+++ b/vendor/github.com/longhorn/sparse-tools/cli/ssync/main.go
@@ -25,6 +25,7 @@ func Main() {
 	port := flag.String("port", "5000", "optional daemon port")
 	timeout := flag.Int("timeout", 120, "optional daemon/client timeout (seconds)")
 	host := flag.String("host", "", "remote host of <DstFile> (requires running daemon)")
+	directIO := flag.Bool("directIO", true, "optional client sync file using directIO")
 
 	flag.Parse()
 
@@ -53,7 +54,7 @@ func Main() {
 		srcPath := args[0]
 		log.Infof("Syncing %s to %s:%s...\n", srcPath, *host, *port)
 
-		err := sparse.SyncFile(srcPath, *host+":"+*port, *timeout)
+		err := sparse.SyncFile(srcPath, *host+":"+*port, *timeout, *directIO)
 		if err != nil {
 			log.Fatalf("Ssync client failed, error: %s", err)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
 # github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003
 github.com/longhorn/nsfilelock
-# github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408
+# github.com/longhorn/sparse-tools v0.0.0-20210322065822-14ef01cc10e9
 github.com/longhorn/sparse-tools/cli/ssync
 github.com/longhorn/sparse-tools/sparse
 github.com/longhorn/sparse-tools/sparse/rest


### PR DESCRIPTION
#### Proposed Changes ####

add command line argument directio to resolve ticket '[BUG] sparse-tools: ssync should explicitly asking for directIO or not, rather than determine is using filesize' (#1943)

1. Update to use `directIO` from the https://github.com/longhorn/sparse-tools/pull/69
1. Update to use `directIO` from the https://github.com/longhorn/sparse-tools/pull/70

#### Types of Changes ####

Bug fixing.

#### Verification ####

Updated/Added unit test cases, and integration test should pass

Build log should have log like following:

```
> grep -rnis directio ./logs_longhorn_longhorn-engine_1_3.log 
81:time="2021-03-22T07:56:54Z" level=info msg="source file size: 178, setting up directIO: false"
82:[test-0faf0f23-replica-1-2] time="2021-03-22T07:56:54Z" level=info msg="open: receiving fileSize: 178, setting up directIO: false"
87:time="2021-03-22T07:56:54Z" level=info msg="source file size: 4194304, setting up directIO: true"
92:time="2021-03-22T07:56:54Z" level=info msg="open: receiving fileSize: 4194304, setting up directIO: true"
96:time="2021-03-22T07:56:54Z" level=info msg="source file size: 126, setting up directIO: false"
101:time="2021-03-22T07:56:54Z" level=info msg="open: receiving fileSize: 126, setting up directIO: false"
793:time="2021-03-22T07:57:27Z" level=info msg="source file size: 178, setting up directIO: false"
794:[test-0faf0f23-replica-1-2] time="2021-03-22T07:57:27Z" level=info msg="open: receiving fileSize: 178, setting up directIO: false"
799:time="2021-03-22T07:57:27Z" level=info msg="source file size: 4194304, setting up directIO: true"
802:time="2021-03-22T07:57:27Z" level=info msg="open: receiving fileSize: 4194304, setting up directIO: true"
```

#### Linked Issues ####

Refs: # https://github.com/longhorn/longhorn/issues/1943

#### Further Comments ####

Signed-off-by: Clark Hsu <clark.hsu@suse.com>