### PR TITLE
Bump longhorn/backupstore version to add KubernetesStatus metadata to volume.cfg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae
+	github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c
 	github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536
 	github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae h1:UL9KjJB5GqC4b83rbPZukW+vP+2b/NNF7pLU+L4J2jI=
-github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
+github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c h1:rWPYE7lzP0n1fj9/vuQxnz9t6hrki+Tc7VCMelugCOI=
+github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c/go.mod h1:9O5tXHnI0KfLXHl+YVey17h9DNq6EIJmBCnNfZH1e18=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536 h1:+Z/mGnoCdY+YCX+y4X19E2YT4FsVA3aVm7uLj1tg/wM=
 github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=

--- a/pkg/backup/main.go
+++ b/pkg/backup/main.go
@@ -108,6 +108,7 @@ func DoBackupCreate(volumeName, snapshotName, destURL, backingImageName, backing
 	volume := &backupstore.Volume{
 		Name:             volumeName,
 		Size:             volumeInfo.Size,
+		Labels:           labelMap,
 		BackingImageName: backingImageName,
 		BackingImageURL:  backingImageURL,
 		CreatedTime:      util.Now(),

--- a/vendor/github.com/longhorn/backupstore/backupstore.go
+++ b/vendor/github.com/longhorn/backupstore/backupstore.go
@@ -10,6 +10,7 @@ import (
 type Volume struct {
 	Name             string
 	Size             int64 `json:",string"`
+	Labels           map[string]string
 	CreatedTime      string
 	LastBackupName   string
 	LastBackupAt     string

--- a/vendor/github.com/longhorn/backupstore/deltablock.go
+++ b/vendor/github.com/longhorn/backupstore/deltablock.go
@@ -325,6 +325,7 @@ func performBackup(config *DeltaBackupConfig, delta *Mappings, deltaBackup *Back
 	volume.BlockCount = volume.BlockCount + newBlocks
 	// The volume may be expanded
 	volume.Size = config.Volume.Size
+	volume.Labels = config.Labels
 	volume.BackingImageName = config.Volume.BackingImageName
 	volume.BackingImageURL = config.Volume.BackingImageURL
 

--- a/vendor/github.com/longhorn/backupstore/list.go
+++ b/vendor/github.com/longhorn/backupstore/list.go
@@ -2,6 +2,7 @@ package backupstore
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	. "github.com/longhorn/backupstore/logging"
@@ -11,6 +12,7 @@ import (
 type VolumeInfo struct {
 	Name           string
 	Size           int64 `json:",string"`
+	Labels         map[string]string
 	Created        string
 	LastBackupName string
 	LastBackupAt   string
@@ -121,6 +123,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 	return &VolumeInfo{
 		Name:             volume.Name,
 		Size:             volume.Size,
+		Labels:           volume.Labels,
 		Created:          volume.CreatedTime,
 		LastBackupName:   volume.LastBackupName,
 		LastBackupAt:     volume.LastBackupAt,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20210202195444-e3b5c5a6d3ae
+# github.com/longhorn/backupstore v0.0.0-20210226025431-845d80a9292c
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
#### Proposed Changes
- Pass labels to backup volume structure
- Bump longhorn/backupstore version to add KubernetesStatus metadata to volume.cfg

#### Linked Issues
https://github.com/longhorn/longhorn/issues/1539