### PR TITLE
Freeze a volumes filesystem if mounted before taking a snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2
-	github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536
+	github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
 	github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-runewidth v0.0.5-0.20181218000649-703b5e6b11ae // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2 h1:9h1zU96KDjBMMOYlZDrnyW/WkHkM5V/9ARpKRYlF280=
 github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
-github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536 h1:+Z/mGnoCdY+YCX+y4X19E2YT4FsVA3aVm7uLj1tg/wM=
-github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b h1:RJukKqQT0ecp6kpB/Vs+pZIrXhSRQJLCTYhPIUO1QzQ=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408 h1:buF1O/6By6sR6lZODDPzl12svm/Yq63FI81hKw9piTk=

--- a/integration/data/test_snapshot.py
+++ b/integration/data/test_snapshot.py
@@ -1,4 +1,6 @@
 import random
+import subprocess
+import pytest
 
 import common.cmd as cmd
 
@@ -9,6 +11,7 @@ from common.core import (  # NOQA
     Data, random_length, random_string,
     expand_volume_with_frontend,
     wait_and_check_volume_expansion,
+    checksum_dev
 )
 
 from common.constants import (
@@ -16,6 +19,8 @@ from common.constants import (
     VOLUME_NAME, VOLUME_BACKING_NAME,
     PAGE_SIZE, SIZE, EXPANDED_SIZE,
 )
+
+from common.util import checksum_data
 
 from data.snapshot_tree import snapshot_tree_build, snapshot_tree_verify_node
 
@@ -366,3 +371,115 @@ def test_expansion_with_backing_file(grpc_backing_controller,  # NOQA
                                          VOLUME_BACKING_NAME,
                                          ENGINE_BACKING_NAME,
                                          read_from_backing_file(0, SIZE))
+
+
+def test_snapshot_mounted_filesystem(grpc_controller,  # NOQA
+                         grpc_replica1, grpc_replica2):  # NOQA
+    """
+    Test that the filesystem on a currently mounted volume
+    will be frozen when a snapshot is requested and that
+    this does not cause issues for the snapshot process.
+
+    1. Create & attach a longhorn volume
+    2. Create & mount an ext4 filesystem on that volume in host namespace
+    3. Ensure volume mount point can be found in host namespace
+    4. Take snapshot 1 (empty filesystem)
+    5. Write test file on the filesystem
+    6. Take snapshot 2 (test file included)
+    7. Overwrite test file on the filesystem
+    8. Take snapshot 3 (test file changed)
+    9. Observe that logs of engine `Filesystem frozen / unfrozen`
+    10. Validate snapshots are created
+    11. Restore snapshot 1, validate test file missing
+    12. Restore snapshot 2, validate test file original content
+    13. Restore snapshot 3, validate test file changed content
+    """
+    address = grpc_controller.address
+    dev = get_dev(grpc_replica1, grpc_replica2, grpc_controller)
+    snapshot_mounted_filesystem_test(VOLUME_NAME, dev, address, ENGINE_NAME)
+
+
+def snapshot_mounted_filesystem_test(volume_name, dev, address, engine_name):  # NOQA
+    dev_path = dev.dev
+    mnt_path = "/tmp/mnt-" + volume_name
+    test_file = mnt_path + "/test"
+    length = 128
+
+    print("dev_path: " + dev_path + "\n")
+    print("mnt_path: " + mnt_path + "\n")
+
+    # create & mount a ext4 filesystem on dev
+    nsenter_cmd = ["nsenter", "--mount=/host/proc/1/ns/mnt",
+                   "--net=/host/proc/1/ns/net", "--"]
+    mount_cmd = nsenter_cmd + ["mount", "--make-shared", dev_path, mnt_path]
+    umount_cmd = nsenter_cmd + ["umount", mnt_path]
+    findmnt_cmd = nsenter_cmd + ["findmnt", dev_path]
+    subprocess.check_call(nsenter_cmd + ["mkfs.ext4", dev_path])
+    subprocess.check_call(nsenter_cmd + ["mkdir", "-p", mnt_path])
+    subprocess.check_call(mount_cmd)
+    subprocess.check_call(findmnt_cmd)
+
+    def checksum_test_file():
+        read_cmd = nsenter_cmd + ["cat", test_file]
+        data = subprocess.check_output(read_cmd)
+        return checksum_data(str(data).encode('utf-8'))
+
+    def write_test_file():
+        # beware don't touch this write command
+        data = random_string(length)
+        write_cmd = ["/bin/sh -c '/bin/echo",
+                     '"' + data + '"', ">", test_file + "'"]
+        shell_cmd = " ".join(nsenter_cmd + write_cmd)
+
+        subprocess.check_call(shell_cmd, shell=True)
+        return checksum_test_file()
+
+    # create snapshot1 with empty fs
+    # NOTE: we cannot use checksum_dev since it assumes
+    #  asci data for device data instead of raw bytes
+    snap1 = cmd.snapshot_create(address)
+
+    # create snapshot2 with a new test file
+    test2_checksum = write_test_file()
+    snap2 = cmd.snapshot_create(address)
+
+    # create snapshot3 overwriting the test file
+    test3_checksum = write_test_file()
+    snap3 = cmd.snapshot_create(address)
+
+    # verify existence of the snapshots
+    snapshots = cmd.snapshot_ls(address)
+    assert snap1 in snapshots
+    assert snap2 in snapshots
+    assert snap3 in snapshots
+
+    # unmount the volume, since each revert will shutdown the device
+    subprocess.check_call(umount_cmd)
+
+    # restore snapshots 1,2,3 & verify filesystem state
+    print("\nsnapshot_revert_with_frontend snap1 begin")
+    snapshot_revert_with_frontend(address, engine_name, snap1)
+    print("snapshot_revert_with_frontend snap1 finish\n")
+    subprocess.check_call(mount_cmd)
+    # should error since the file does not exist in snapshot 1
+    with pytest.raises(subprocess.CalledProcessError):
+        print("is expected error, since the file does not exist.")
+        checksum_test_file()
+    subprocess.check_call(umount_cmd)
+
+    print("\nsnapshot_revert_with_frontend snap2 begin")
+    snapshot_revert_with_frontend(address, engine_name, snap2)
+    print("snapshot_revert_with_frontend snap2 finish\n")
+    subprocess.check_call(mount_cmd)
+    assert checksum_test_file() == test2_checksum
+    subprocess.check_call(umount_cmd)
+
+    print("\nsnapshot_revert_with_frontend snap3 begin")
+    snapshot_revert_with_frontend(address, engine_name, snap3)
+    print("snapshot_revert_with_frontend snap3 finish\n")
+    subprocess.check_call(mount_cmd)
+    assert checksum_test_file() == test3_checksum
+    subprocess.check_call(umount_cmd)
+
+    # remove the created mount folder
+    subprocess.check_call(nsenter_cmd + ["rmdir", mnt_path])

--- a/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
+++ b/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
@@ -154,12 +154,12 @@ func ExecuteWithTimeout(timeout time.Duration, binary string, args []string) (st
 			}
 
 		}
-		return "", fmt.Errorf("Timeout executing: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("Timeout executing: %v %v, output %s, stderr, %s, error %w",
 			binary, args, output.String(), stderr.String(), err)
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %w",
 			binary, args, output.String(), stderr.String(), err)
 	}
 	return output.String(), nil
@@ -176,7 +176,7 @@ func ExecuteWithoutTimeout(binary string, args []string) (string, error) {
 	cmd.Stderr = &stderr
 
 	if err = cmd.Run(); err != nil {
-		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %w",
 			binary, args, output.String(), stderr.String(), err)
 	}
 	return output.String(), nil
@@ -228,12 +228,12 @@ func ExecuteWithStdin(binary string, args []string, stdinString string) (string,
 			}
 
 		}
-		return "", fmt.Errorf("Timeout executing: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("Timeout executing: %v %v, output %s, stderr, %s, error %w",
 			binary, args, output.String(), stderr.String(), err)
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %w",
 			binary, args, output.String(), stderr.String(), err)
 	}
 	return output.String(), nil
@@ -246,7 +246,7 @@ func RemoveFile(file string) error {
 	}
 
 	if err := remove(file); err != nil {
-		return fmt.Errorf("fail to remove file %v: %v", file, err)
+		return fmt.Errorf("fail to remove file %v: %w", file, err)
 	}
 
 	return nil
@@ -255,7 +255,7 @@ func RemoveFile(file string) error {
 func RemoveDevice(dev string) error {
 	if _, err := os.Stat(dev); err == nil {
 		if err := remove(dev); err != nil {
-			return fmt.Errorf("Failed to removing device %s, %v", dev, err)
+			return fmt.Errorf("Failed to removing device %s, %w", dev, err)
 		}
 	}
 	return nil
@@ -307,7 +307,7 @@ func DuplicateDevice(dev *KernelDevice, dest string) error {
 		return fmt.Errorf("Cannot create device node %s for device %s", dest, dev.Name)
 	}
 	if err := os.Chmod(dest, 0660); err != nil {
-		return fmt.Errorf("Couldn't change permission of the device %s: %s", dest, err)
+		return fmt.Errorf("Couldn't change permission of the device %s: %w", dest, err)
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/longhorn/backupstore/nfs
 github.com/longhorn/backupstore/s3
 github.com/longhorn/backupstore/util
 github.com/longhorn/backupstore/vfs
-# github.com/longhorn/go-iscsi-helper v0.0.0-20201111045018-ee87992ec536
+# github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
 github.com/longhorn/go-iscsi-helper/iscsi
 github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev


### PR DESCRIPTION
We evaluate whether the fs is mounted by running `findmnt /dev/longhorn/<volume_name>` in the host mount namespace.

Since if the volume is used, the engine will be on the same node as the workload
that is using it and the volume will be mounted by kubelet in the host mount namespace.

In the case where the volume is not mounted we fall back to a system level sync.

I added an integration test, that mounts the device in the host mount namespace and writes some file onto it. Then does snapshots & restores.
I need to mount&umount the device after the restore, since the test will shutdown the frontend. This is equivalent to our killing of the workload pods, to get the volume to remount.

longhorn/longhorn#2187

depends on an update of the go-iscsi-helper dependency which is included
as a dev commit and will be replaced once this pr is merged.
https://github.com/longhorn/go-iscsi-helper/pull/38