### PR TITLE
add logs for debugging snapshot (#2161)

### DIFF
--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -83,7 +83,7 @@ func (r *Remote) open() error {
 }
 
 func (r *Remote) Snapshot(name string, userCreated bool, created string, labels map[string]string) error {
-	logrus.Infof("Snapshot: %s %s UserCreated %v Created at %v, Labels %v",
+	logrus.Infof("Starting to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
 		r.name, name, userCreated, created, labels)
 	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure())
 	if err != nil {
@@ -103,7 +103,8 @@ func (r *Remote) Snapshot(name string, userCreated bool, created string, labels 
 	}); err != nil {
 		return fmt.Errorf("failed to snapshot replica %v from remote: %v", r.replicaServiceURL, err)
 	}
-
+	logrus.Infof("Finished to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
+		r.name, name, userCreated, created, labels)
 	return nil
 }
 

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -808,6 +808,8 @@ func (r *Replica) revertDisk(parent, created string) (*Replica, error) {
 }
 
 func (r *Replica) createDisk(name string, userCreated bool, created string, labels map[string]string, size int64) (err error) {
+	log := logrus.WithFields(logrus.Fields{"disk": name})
+	log.Info("Starting to create disk")
 	if r.readOnly {
 		return fmt.Errorf("Can not create disk on read-only replica")
 	}
@@ -830,7 +832,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	defer func() {
 		var rollbackErr error
 		if err != nil {
-			logrus.Errorf("failed to create disk %v, will do rollback: %v", name, err)
+			log.WithError(err).Errorf("failed to create disk %v, will do rollback", name)
 			delete(r.diskData, newHeadDisk.Name)
 			delete(r.diskData, newSnapName)
 			delete(r.diskChildrenMap, newSnapName)
@@ -882,6 +884,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	r.volume.files = append(r.volume.files, f)
 	r.activeDiskData = append(r.activeDiskData, &newHeadDisk)
 
+	log.Info("Finished creating disk")
 	return nil
 }
 


### PR DESCRIPTION
#### Proposed Changes ####

add logs for debugging snapshot to resolve ticket '[FEATURE]Add more debug logs for snapshotting' (#2161)

- add snapshot time
- add sendfile time

#### Types of Changes ####

- enhancement

#### Verification ####

Additional log like following

2021-03-04T04:10:53.970318517Z time="2021-03-04T04:10:53Z" level=info msg="Finish snapshot for tcp://10.42.1.12:10000: 075a33e7-343b-4cad-b0c6-ff9c19016ec5 and take 2.63582ms"

2021-03-04T04:10:53.970318517Z time="2021-03-04T04:10:53Z" level=info msg="Finish sending file /tmp/test256KB.tmp and take 1.644776033s"

#### Linked Issues ####

Refs: # https://github.com/longhorn/longhorn/issues/2161

#### Further Comments ####

Wait for https://github.com/longhorn/sparse-tools/pull/71 to update go.mod, go.sum, and module.txt

Signed-off-by: Clark Hsu <clark.hsu@suse.com>