### PR TITLE
Update longhorn/backupstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2
+	github.com/longhorn/backupstore v0.0.0-20210311053000-a6c606557ab0
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
 	github.com/longhorn/sparse-tools v0.0.0-20201111045115-7a3bbbb6f408
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2 h1:9h1zU96KDjBMMOYlZDrnyW/WkHkM5V/9ARpKRYlF280=
-github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
+github.com/longhorn/backupstore v0.0.0-20210311053000-a6c606557ab0 h1:sgDTtwveDuzoRUDISh+YunZa/EFgL9R259qpx6cf5AY=
+github.com/longhorn/backupstore v0.0.0-20210311053000-a6c606557ab0/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b h1:RJukKqQT0ecp6kpB/Vs+pZIrXhSRQJLCTYhPIUO1QzQ=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=

--- a/vendor/github.com/longhorn/backupstore/fsops/fsops.go
+++ b/vendor/github.com/longhorn/backupstore/fsops/fsops.go
@@ -114,7 +114,9 @@ func (f *FileSystemOperator) Write(dst string, rs io.ReadSeeker) error {
 
 func (f *FileSystemOperator) List(path string) ([]string, error) {
 	out, err := util.Execute("ls", []string{"-1", f.LocalPath(path)})
-	if err != nil {
+	if err != nil &&
+		!strings.Contains(err.Error(), "No such file or directory") &&
+		!strings.Contains(err.Error(), "cannot open directory") {
 		return nil, err
 	}
 	var result []string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/honestbee/jobq
 github.com/jmespath/go-jmespath
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/longhorn/backupstore v0.0.0-20210304124311-0aee37c899e2
+# github.com/longhorn/backupstore v0.0.0-20210311053000-a6c606557ab0
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
Include error handling backupstore.List when fsops path not exist.

https://github.com/longhorn/backupstore/pull/66
https://github.com/longhorn/longhorn/issues/2312
