### PR TITLE
Add error log when read volume.meta failed

### DIFF
--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -110,6 +110,7 @@ func (s *Server) Status() (State, Info) {
 		if os.IsNotExist(err) {
 			return Initial, Info{}
 		} else if err != nil {
+			logrus.Errorf("Failed to read info in replica directory %s: %v", s.dir, err)
 			return Error, Info{}
 		}
 		return Closed, info


### PR DESCRIPTION
#### Symptom
The user uses longhorn-engine version v1.0.2, and the log fulls with
```shell
time="2021-01-22T02:36:05Z" level=warning msg="pvc-24e08e51-3db8-45b4-8860-4f1adcccd9c7-e-bc240ffa: time="2021-01-22T02:35:51Z" level=info msg="Starting with replicas [\"tcp://10.42.0.254:10000\"]""
time="2021-01-22T02:36:05Z" level=warning msg="pvc-24e08e51-3db8-45b4-8860-4f1adcccd9c7-e-bc240ffa: time="2021-01-22T02:35:51Z" level=info msg="Connecting to remote: 10.42.0.254:10000""
time="2021-01-22T02:36:05Z" level=warning msg="pvc-24e08e51-3db8-45b4-8860-4f1adcccd9c7-e-bc240ffa: time="2021-01-22T02:35:51Z" level=warning msg="failed to create backend with address tcp://10.42.0.254:10000: Replica must be closed, Can not add in state: error""
time="2021-01-22T02:36:05Z" level=warning msg="pvc-24e08e51-3db8-45b4-8860-4f1adcccd9c7-e-bc240ffa: time="2021-01-22T02:35:51Z" level=info msg="Adding backend: tcp://10.42.0.254:10000""
time="2021-01-22T02:36:05Z" level=warning msg="pvc-24e08e51-3db8-45b4-8860-4f1adcccd9c7-e-bc240ffa: 2021/01/22 02:35:51 cannot create an available backend for the engine from the addresses [tcp://10.42.0.254:10000]"
```

#### Root cause
It should be https://github.com/longhorn/longhorn-engine/blob/v1.0.2/pkg/replica/server.go#L119-L120 and https://github.com/longhorn/longhorn-engine/blob/v1.0.2/pkg/replica/replica.go#L991-L1001, either:
- `os.Open` error: I've no idea now how to make this happens :thinking: 
- `json.Decode` error: it's not hard to reproduce the `json.Decode` it, we could change one of the `volume.meta` value from boolean to string, then the issue happens. For example:
   - Deploy single node Longhorn cluster
   - Deploy an application with volume mounted on it and replica count = 2
   - Detach the volume
   - Edit the volume.meta on the host `/var/lib/longhorn/replicas/pvc-xxx/volume.meta`
      ```shell
      sed -i s/'"Dirty":false'/'"Dirty":"false"'/ ./volume.meta
      ```
    - Attach the volume back

#### Propose change
Since we can't 100% sure which function reports the error, either `os.Open` or `json.Decode`. Let's add an error log to help us know the real problem is. For example, the replica instance manager log
```shell
[pvc-216ec496-cd12-47a9-b535-b00971e725d7-r-5c546c4e] time="2021-04-06T06:47:09Z" level=error msg="Failed to read info in replica directory /host/var/lib/longhorn/replicas/pvc-216ec496-cd12-47a9-b535-b00971e725d7-77668094: json: cannot unmarshal string into Go struct field Info.Dirty of type bool"
```

#### Linked issue
https://github.com/longhorn/longhorn/issues/2204
