### PR TITLE
Bump longhorn/go-iscsi-helper version to fix typo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7
-	github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
+	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 	github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-runewidth v0.0.5-0.20181218000649-703b5e6b11ae // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7 h1:7oaRicf7Yv
 github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b h1:RJukKqQT0ecp6kpB/Vs+pZIrXhSRQJLCTYhPIUO1QzQ=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb h1:FV55CUsHOSa50wGNb3z9/irkn44fXeMjYHV2eIE5DAE=

--- a/vendor/github.com/longhorn/go-iscsi-helper/iscsi/initiator.go
+++ b/vendor/github.com/longhorn/go-iscsi-helper/iscsi/initiator.go
@@ -121,7 +121,7 @@ func LoginTarget(ip, target string, ne *util.NamespaceExecutor) error {
 			return errors.Wrapf(err, "Failed to manually rescan iscsi session of target %v:%v", target, ip)
 		}
 	} else {
-		logrus.Infof("default: automatically rescan all LUNs of all iscis sessions")
+		logrus.Infof("default: automatically rescan all LUNs of all iscsi sessions")
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/longhorn/backupstore/nfs
 github.com/longhorn/backupstore/s3
 github.com/longhorn/backupstore/util
 github.com/longhorn/backupstore/vfs
-# github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
+# github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 github.com/longhorn/go-iscsi-helper/iscsi
 github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev


### PR DESCRIPTION
Bump version to includes https://github.com/longhorn/go-iscsi-helper/pull/39

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>