### PR TITLE
Backport replica rebuild enhancement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7
-	github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
-	github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb
+	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
+	github.com/longhorn/sparse-tools v0.0.0-20210608154118-5a6415ebe755
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-runewidth v0.0.5-0.20181218000649-703b5e6b11ae // indirect
 	github.com/moby/moby v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,12 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7 h1:7oaRicf7Yvq9/j1KlUAd8Ynv3VLrUulZgc6NQ3hzcQs=
 github.com/longhorn/backupstore v0.0.0-20210512104317-89bd8d273db7/go.mod h1:UOpvZ/qRS2G8BBSybHuS/c4h1P21XTEnL2hoJz2JUuo=
-github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b h1:RJukKqQT0ecp6kpB/Vs+pZIrXhSRQJLCTYhPIUO1QzQ=
-github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
+github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
-github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb h1:FV55CUsHOSa50wGNb3z9/irkn44fXeMjYHV2eIE5DAE=
-github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb/go.mod h1:1WSSJRDNret4VKADAzvD49oaVt1/idYVWBL8TiyevRk=
+github.com/longhorn/sparse-tools v0.0.0-20210608154118-5a6415ebe755 h1:z7fyrYoAvT4ty7pt11ihS8rdCGbRIuBIa6BudZtPwAk=
+github.com/longhorn/sparse-tools v0.0.0-20210608154118-5a6415ebe755/go.mod h1:1WSSJRDNret4VKADAzvD49oaVt1/idYVWBL8TiyevRk=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/vendor/github.com/longhorn/go-iscsi-helper/iscsi/initiator.go
+++ b/vendor/github.com/longhorn/go-iscsi-helper/iscsi/initiator.go
@@ -121,7 +121,7 @@ func LoginTarget(ip, target string, ne *util.NamespaceExecutor) error {
 			return errors.Wrapf(err, "Failed to manually rescan iscsi session of target %v:%v", target, ip)
 		}
 	} else {
-		logrus.Infof("default: automatically rescan all LUNs of all iscis sessions")
+		logrus.Infof("default: automatically rescan all LUNs of all iscsi sessions")
 	}
 
 	return nil

--- a/vendor/github.com/longhorn/sparse-tools/sparse/rest/handlers.go
+++ b/vendor/github.com/longhorn/sparse-tools/sparse/rest/handlers.go
@@ -162,7 +162,7 @@ func (server *SyncServer) doGetChecksum(writer http.ResponseWriter, request *htt
 	var checksum []byte
 
 	// For the region to have valid data, it can only has one extent covering the whole region
-	exts, err := sparse.GetFiemapRegionExts(server.fileIo, remoteDataInterval)
+	exts, err := sparse.GetFiemapRegionExts(server.fileIo, remoteDataInterval, 2)
 	if len(exts) == 1 && int64(exts[0].Logical) <= remoteDataInterval.Begin &&
 		int64(exts[0].Logical+exts[0].Length) >= remoteDataInterval.End {
 

--- a/vendor/github.com/longhorn/sparse-tools/sparse/util.go
+++ b/vendor/github.com/longhorn/sparse-tools/sparse/util.go
@@ -1,0 +1,61 @@
+package sparse
+
+import (
+	"context"
+	"sync"
+)
+
+// mergeErrorChannels will merge all error channels into a single error out channel.
+// the error out channel will be closed once the ctx is done or all error channels are closed
+// if there is an error on one of the incoming channels the error will be relayed.
+func mergeErrorChannels(ctx context.Context, channels ...<-chan error) <-chan error {
+	var wg sync.WaitGroup
+	wg.Add(len(channels))
+
+	out := make(chan error, len(channels))
+	output := func(c <-chan error) {
+		defer wg.Done()
+		select {
+		case err, ok := <-c:
+			if ok {
+				out <- err
+			}
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	for _, c := range channels {
+		go output(c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+func processFileIntervals(ctx context.Context, in <-chan FileInterval, processInterval func(interval FileInterval) error) <-chan error {
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case interval, open := <-in:
+				if !open {
+					return
+				}
+
+				if err := processInterval(interval); err != nil {
+					errc <- err
+					return
+				}
+			}
+		}
+	}()
+	return errc
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/longhorn/backupstore/nfs
 github.com/longhorn/backupstore/s3
 github.com/longhorn/backupstore/util
 github.com/longhorn/backupstore/vfs
-# github.com/longhorn/go-iscsi-helper v0.0.0-20210304120829-4c21e728023b
+# github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 github.com/longhorn/go-iscsi-helper/iscsi
 github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev
@@ -82,7 +82,7 @@ github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
 # github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003
 github.com/longhorn/nsfilelock
-# github.com/longhorn/sparse-tools v0.0.0-20210420073041-5c51de69e0eb
+# github.com/longhorn/sparse-tools v0.0.0-20210608154118-5a6415ebe755
 github.com/longhorn/sparse-tools/cli/ssync
 github.com/longhorn/sparse-tools/sparse
 github.com/longhorn/sparse-tools/sparse/rest


### PR DESCRIPTION
Backport sparse-tools update for iterative sync/fold

This also has a typo fix for the go-iscsi-helper dependency this is already
in master, since it doesn't have a semantic change I included it as well.

longhorn/longhorn#1948
longhorn/longhorn#2507
longhorn/longhorn#2640