### PR TITLE
Timeout replica when no I/O responses are received

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -96,7 +96,7 @@ RUN go get \
 RUN cd /usr/src && \
     git clone https://github.com/rancher/liblonghorn.git && \
     cd liblonghorn && \
-    git checkout 6592b9967d1b5acbb51a5596abfe0a0d7bad16dc && \
+    git checkout 9eaf16c13dccc7f3bdb111d4e21662ae753bdccf && \
     make deb && \
     dpkg -i ./pkg/liblonghorn_*.deb
 

--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -20,9 +21,12 @@ import (
 )
 
 var (
-	pingInveral   = 2 * time.Second
-	timeout       = 30 * time.Second
-	requestBuffer = 1024
+	ErrPingTimeout = errors.New("ping timeout")
+)
+
+const (
+	PingInterval = 2 * time.Second
+	PingTimeout  = 8 * time.Second
 )
 
 func New() types.BackendFactory {
@@ -284,7 +288,10 @@ func (rf *Factory) Create(address string) (types.Backend, error) {
 }
 
 func (r *Remote) monitorPing(client *dataconn.Client) {
-	ticker := time.NewTicker(pingInveral)
+	pingStatus := make(chan error, 1)
+	pingDeadline := time.Time{}
+	inProgress := false
+	ticker := time.NewTicker(PingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -293,13 +300,35 @@ func (r *Remote) monitorPing(client *dataconn.Client) {
 			r.monitorChan <- nil
 			return
 		case <-ticker.C:
-			if err := client.Ping(); err != nil {
+			if !inProgress {
+				inProgress = true
+				pingDeadline = time.Now().Add(PingTimeout)
+				r.ping(client, pingStatus)
+				continue
+			}
+
+			if time.Now().After(pingDeadline) {
+				client.SetError(ErrPingTimeout)
+				r.monitorChan <- ErrPingTimeout
+				return
+			}
+
+		case err := <-pingStatus:
+			inProgress = false
+
+			if err != nil {
 				client.SetError(err)
 				r.monitorChan <- err
 				return
 			}
 		}
 	}
+}
+
+func (r *Remote) ping(client *dataconn.Client, status chan<- error) {
+	go func() {
+		status <- client.Ping()
+	}()
 }
 
 func (r *Remote) GetMonitorChannel() types.MonitorChannel {


### PR DESCRIPTION
This changes the timeout logic in dataconn.Conn.  Previously the timeout occurred when a response operation was not received for eight seconds (with one retry).   When multiple operations were being performed simultaneously on a slow disk, this timeout was likely to occur.  However, when multiple operations were being performed simultaneously, the replica is regularly sending responses to those operations.  So, this change makes the timeout occur when no response to any of the pending read or write operation has been received for eight seconds. 

This will allow slow disks to not timeout because the replica will be completing and sending the responses to operation regularly.   This addresses slow disks failing as part of #2206 but doesn't fixed the performance issue will spinning disks in general.

https://github.com/longhorn/longhorn/issues/2206