### PR TITLE
Stop monitoring goroutine when removing replica

### DIFF
--- a/pkg/controller/replicator.go
+++ b/pkg/controller/replicator.go
@@ -79,6 +79,9 @@ func (r *replicator) RemoveBackend(address string) {
 	// We cannot wait for it's return because peer may not exists anymore
 	// The backend may be nil if the mode is ERR
 	if backend.backend != nil {
+		// Stop the monitoring goroutine in the Controller
+		backend.backend.StopMonitoring()
+
 		go backend.backend.Close()
 	}
 	delete(r.backends, address)


### PR DESCRIPTION
The monitoring goroutine was continuing to run after the replica was
removed.  This caused a problem when a replica is recreated for the same
IP address and port after one is deleted.  When a replica is removed,
the channel that the monitoring goroutine is waiting for will eventually
get an error message.  In the normal case, the SetReplicaMode won't find
a replica with the address to mark as ERR.  However, when another
replica is with the same address is added after the original was
removed, SetReplicaMode for the old monitorChan will mark the new
replica as ERR with SetReplicaMode.

This change makes removing the replica also stop the monitoring
goroutine that was launched for that replica.  It puts a nil error on
the replica's monitor channel so monitoring goroutine  will exit as part
of removing the replica.

longhorn/longhorn#1628

Signed-off-by: Keith Lucas <keith.lucas@suse.com>