### PR TITLE
Make closing all the replicas stop all the replica monitors

### DIFF
--- a/pkg/controller/replicator.go
+++ b/pkg/controller/replicator.go
@@ -292,6 +292,9 @@ func (r *replicator) Close() error {
 		if backend.mode == types.ERR {
 			continue
 		}
+
+		backend.backend.StopMonitoring()
+
 		if err := backend.backend.Close(); err != nil {
 			lastErr = err
 		}


### PR DESCRIPTION
The replica monitor channel goroutine is still running when a
controller's volume is shutdown via the GRPC VolumeShutdown method.
This change makes stops the Controller's replica monitor goroutine when
the volume is shutdown.

https://github.com/longhorn/longhorn/issues/1628

Signed-off-by: Keith Lucas <keith.lucas@suse.com>