### PR TITLE
Add instance manager cli back to engine image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -113,12 +113,11 @@ RUN mkdir integration/
 COPY integration/setup.py integration/tox.ini integration/requirements.txt integration/flake8-requirements.txt integration/
 RUN cd integration && tox --notest
 
-# Build longhorn-instance-manager for integraiton testing
+# Build longhorn-instance-manager for integration testing
 RUN cd /go/src/github.com/longhorn && \
     git clone https://github.com/longhorn/longhorn-instance-manager.git && \
     cd longhorn-instance-manager && \
-    im_release=$(curl -sfSL https://api.github.com/repos/longhorn/longhorn-instance-manager/releases/latest | jq -r '.tag_name') && \
-    git checkout ${im_release} && \
+    git checkout v1_20210621 && \
     go build -o ./longhorn-instance-manager && \
     cp -r integration/rpc/ ${DAPPER_SOURCE}/integration/rpc/ && \
     cp longhorn-instance-manager /usr/local/bin

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-${ARCH} -O /usr/local/bin/grpc_health_probe && \
     chmod +x /usr/local/bin/grpc_health_probe
 
-COPY bin/longhorn /usr/local/bin/
+COPY bin/longhorn bin/longhorn-instance-manager /usr/local/bin/
 
 COPY package/launch-simple-longhorn package/engine-manager package/launch-simple-file /usr/local/bin/
 


### PR DESCRIPTION
Signed-off-by: David Ko <dko@suse.com>

ref: https://github.com/longhorn/longhorn/issues/2796
note: This will be backported to v1.1.3.
