### PR TITLE
2818-bulk-backup-status-retrieval

### DIFF
--- a/app/cmd/add_replica.go
+++ b/app/cmd/add_replica.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,7 +37,12 @@ func addReplica(c *cli.Context) error {
 	replica := c.Args()[0]
 
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task, err := sync.NewTask(ctx, url)
+	if err != nil {
+		return err
+	}
 
 	if c.Bool("restore") {
 		return task.AddRestoreReplica(replica)
@@ -63,7 +69,13 @@ func startWithReplicas(c *cli.Context) error {
 	replicas := c.Args()
 
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task, err := sync.NewTask(ctx, url)
+	if err != nil {
+		return err
+	}
+
 	return task.StartWithReplicas(replicas)
 }
 
@@ -80,7 +92,14 @@ func RebuildStatusCmd() cli.Command {
 }
 
 func rebuildStatus(c *cli.Context) error {
-	task := sync.NewTask(c.GlobalString("url"))
+	url := c.GlobalString("url")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task, err := sync.NewTask(ctx, url)
+	if err != nil {
+		return err
+	}
+
 	statusMap, err := task.RebuildStatus()
 	if err != nil {
 		return err
@@ -112,8 +131,15 @@ func verifyRebuildReplica(c *cli.Context) error {
 		return errors.New("replica address is required")
 	}
 	address := c.Args()[0]
+	url := c.GlobalString("url")
 
-	task := sync.NewTask(c.GlobalString("url"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task, err := sync.NewTask(ctx, url)
+	if err != nil {
+		return err
+	}
+
 	if err := task.VerifyRebuildReplica(address); err != nil {
 		return err
 	}

--- a/app/cmd/backup.go
+++ b/app/cmd/backup.go
@@ -91,7 +91,11 @@ func getBackupStatus(c *cli.Context, backupID string, replicaAddress string) (*s
 }
 
 func getReplicaModeMap(c *cli.Context) (map[string]types.Mode, error) {
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return nil, err
+	}
+
 	replicas, err := controllerClient.ReplicaList()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get replica list: %v", err)
@@ -108,7 +112,12 @@ func getReplicaModeMap(c *cli.Context) (map[string]types.Mode, error) {
 func fetchAllBackups(c *cli.Context) error {
 	backupProgressList := make(map[string]*sync.BackupStatusInfo)
 
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	backupReplicaMap, err := controllerClient.BackupReplicaMappingGet()
 	if err != nil {
 		return fmt.Errorf("failed to get list of backupIDs: %v", err)
@@ -179,7 +188,12 @@ func checkBackupStatus(c *cli.Context) error {
 		return fetchAllBackups(c)
 	}
 
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	br, err := controllerClient.BackupReplicaMappingGet()
 	if err != nil {
 		return err

--- a/app/cmd/controller.go
+++ b/app/cmd/controller.go
@@ -122,7 +122,7 @@ func startController(c *cli.Context) error {
 	return control.WaitForShutdown()
 }
 
-func getControllerClient(c *cli.Context) *client.ControllerClient {
+func getControllerClient(c *cli.Context) (*client.ControllerClient, error) {
 	url := c.GlobalString("url")
 	return client.NewControllerClient(url)
 }

--- a/app/cmd/ls_replica.go
+++ b/app/cmd/ls_replica.go
@@ -56,6 +56,7 @@ func getChain(address string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer repClient.Close()
 
 	r, err := repClient.GetReplica()
 	if err != nil {

--- a/app/cmd/ls_replica.go
+++ b/app/cmd/ls_replica.go
@@ -25,7 +25,12 @@ func LsReplicaCmd() cli.Command {
 }
 
 func lsReplica(c *cli.Context) error {
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	reps, err := controllerClient.ReplicaList()
 	if err != nil {
 		return err

--- a/app/cmd/rm_replica.go
+++ b/app/cmd/rm_replica.go
@@ -25,6 +25,11 @@ func rmReplica(c *cli.Context) error {
 	}
 	replica := c.Args()[0]
 
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	return controllerClient.ReplicaDelete(replica)
 }

--- a/app/cmd/snapshot.go
+++ b/app/cmd/snapshot.go
@@ -145,7 +145,12 @@ func createSnapshot(c *cli.Context) error {
 		}
 	}
 
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	id, err := controllerClient.VolumeSnapshot(name, labelMap)
 	if err != nil {
 		return err
@@ -161,9 +166,13 @@ func revertSnapshot(c *cli.Context) error {
 		return fmt.Errorf("Missing parameter for snapshot")
 	}
 
-	controllerClient := getControllerClient(c)
-	err := controllerClient.VolumeRevert(name)
+	controllerClient, err := getControllerClient(c)
 	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
+	if err = controllerClient.VolumeRevert(name); err != nil {
 		return err
 	}
 
@@ -214,7 +223,12 @@ func purgeSnapshotStatus(c *cli.Context) error {
 }
 
 func lsSnapshot(c *cli.Context) error {
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	replicas, err := controllerClient.ReplicaList()
 	if err != nil {
 		return err
@@ -267,7 +281,12 @@ func lsSnapshot(c *cli.Context) error {
 func infoSnapshot(c *cli.Context) error {
 	var output []byte
 
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	replicas, err := controllerClient.ReplicaList()
 	if err != nil {
 		return err

--- a/app/cmd/stats.go
+++ b/app/cmd/stats.go
@@ -16,9 +16,13 @@ func Journal() cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) {
-			controllerClient := getControllerClient(c)
-			err := controllerClient.JournalList(c.Int("limit"))
+			controllerClient, err := getControllerClient(c)
 			if err != nil {
+				logrus.Fatalln("Error running journal command:", err)
+			}
+			defer controllerClient.Close()
+
+			if err = controllerClient.JournalList(c.Int("limit")); err != nil {
 				logrus.Fatalln("Error running journal command:", err)
 			}
 		},

--- a/app/cmd/sync_agent.go
+++ b/app/cmd/sync_agent.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -89,7 +90,13 @@ func startSyncAgent(c *cli.Context) error {
 }
 
 func doReset(c *cli.Context) error {
-	task := sync.NewTask(c.GlobalString("url"))
+	url := c.GlobalString("url")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	task, err := sync.NewTask(ctx, url)
+	if err != nil {
+		return err
+	}
 
 	if err := task.Reset(); err != nil {
 		logrus.Errorf("Failed to reset sync agent server")

--- a/app/cmd/volume.go
+++ b/app/cmd/volume.go
@@ -71,7 +71,12 @@ func FrontendShutdownCmd() cli.Command {
 }
 
 func info(c *cli.Context) error {
-	controllerClient := getControllerClient(c)
+	controllerClient, err := getControllerClient(c)
+	if err != nil {
+		return err
+	}
+	defer controllerClient.Close()
+
 	volumeInfo, err := controllerClient.VolumeGet()
 	if err != nil {
 		return err
@@ -88,13 +93,13 @@ func info(c *cli.Context) error {
 
 func expand(c *cli.Context) error {
 	size := c.Int64("size")
-	controllerClient := getControllerClient(c)
-	err := controllerClient.VolumeExpand(size)
+	controllerClient, err := getControllerClient(c)
 	if err != nil {
 		return err
 	}
+	defer controllerClient.Close()
 
-	return nil
+	return controllerClient.VolumeExpand(size)
 }
 
 func startFrontend(c *cli.Context) error {
@@ -103,21 +108,21 @@ func startFrontend(c *cli.Context) error {
 		return fmt.Errorf("Missing required parameter frontendName")
 	}
 
-	controllerClient := getControllerClient(c)
-	err := controllerClient.VolumeFrontendStart(frontendName)
+	controllerClient, err := getControllerClient(c)
 	if err != nil {
 		return err
 	}
+	defer controllerClient.Close()
 
-	return nil
+	return controllerClient.VolumeFrontendStart(frontendName)
 }
 
 func shutdownFrontend(c *cli.Context) error {
-	controllerClient := getControllerClient(c)
-	err := controllerClient.VolumeFrontendShutdown()
+	controllerClient, err := getControllerClient(c)
 	if err != nil {
 		return err
 	}
+	defer controllerClient.Close()
 
-	return nil
+	return controllerClient.VolumeFrontendShutdown()
 }

--- a/pkg/controller/client/controller_client.go
+++ b/pkg/controller/client/controller_client.go
@@ -15,18 +15,54 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
+type ControllerServiceContext struct {
+	cc      *grpc.ClientConn
+	service ptypes.ControllerServiceClient
+}
+
+func (c ControllerServiceContext) Close() error {
+	if c.cc == nil {
+		return nil
+	}
+	return c.cc.Close()
+}
+
 type ControllerClient struct {
-	grpcAddress string
+	serviceURL string
+	ControllerServiceContext
+}
+
+func (c *ControllerClient) getControllerServiceClient() ptypes.ControllerServiceClient {
+	return c.service
 }
 
 const (
 	GRPCServiceTimeout = 3 * time.Minute
 )
 
-func NewControllerClient(address string) *ControllerClient {
-	return &ControllerClient{
-		grpcAddress: util.GetGRPCAddress(address),
+func NewControllerClient(address string) (*ControllerClient, error) {
+	getControllerServiceContext := func(serviceUrl string) (ControllerServiceContext, error) {
+		connection, err := grpc.Dial(serviceUrl, grpc.WithInsecure())
+		if err != nil {
+			return ControllerServiceContext{}, fmt.Errorf("cannot connect to ControllerService %v: %v", serviceUrl, err)
+		}
+
+		return ControllerServiceContext{
+			cc:      connection,
+			service: ptypes.NewControllerServiceClient(connection),
+		}, nil
 	}
+
+	serviceURL := util.GetGRPCAddress(address)
+	serviceContext, err := getControllerServiceContext(serviceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ControllerClient{
+		serviceURL:               serviceURL,
+		ControllerServiceContext: serviceContext,
+	}, nil
 }
 
 func GetVolumeInfo(v *ptypes.Volume) *types.VolumeInfo {
@@ -76,52 +112,34 @@ func GetSyncFileInfo(info *ptypes.SyncFileInfo) types.SyncFileInfo {
 }
 
 func (c *ControllerClient) VolumeGet() (*types.VolumeInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	volume, err := controllerServiceClient.VolumeGet(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get volume %v: %v", c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to get volume %v: %v", c.serviceURL, err)
 	}
 
 	return GetVolumeInfo(volume), nil
 }
 
 func (c *ControllerClient) VolumeStart(replicas ...string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.VolumeStart(ctx, &ptypes.VolumeStartRequest{
 		ReplicaAddresses: replicas,
 	}); err != nil {
-		return fmt.Errorf("failed to start volume %v: %v", c.grpcAddress, err)
+		return fmt.Errorf("failed to start volume %v: %v", c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) VolumeSnapshot(name string, labels map[string]string) (string, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return "", fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -130,104 +148,74 @@ func (c *ControllerClient) VolumeSnapshot(name string, labels map[string]string)
 		Labels: labels,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create snapshot %v for volume %v: %v", name, c.grpcAddress, err)
+		return "", fmt.Errorf("failed to create snapshot %v for volume %v: %v", name, c.serviceURL, err)
 	}
 
 	return reply.Name, nil
 }
 
 func (c *ControllerClient) VolumeRevert(snapshot string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.VolumeRevert(ctx, &ptypes.VolumeRevertRequest{
 		Name: snapshot,
 	}); err != nil {
-		return fmt.Errorf("failed to revert to snapshot %v for volume %v: %v", snapshot, c.grpcAddress, err)
+		return fmt.Errorf("failed to revert to snapshot %v for volume %v: %v", snapshot, c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) VolumeExpand(size int64) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.VolumeExpand(ctx, &ptypes.VolumeExpandRequest{
 		Size: size,
 	}); err != nil {
-		return fmt.Errorf("failed to expand to size %v for volume %v: %v", size, c.grpcAddress, err)
+		return fmt.Errorf("failed to expand to size %v for volume %v: %v", size, c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) VolumeFrontendStart(frontend string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.VolumeFrontendStart(ctx, &ptypes.VolumeFrontendStartRequest{
 		Frontend: frontend,
 	}); err != nil {
-		return fmt.Errorf("failed to start frontend %v for volume %v: %v", frontend, c.grpcAddress, err)
+		return fmt.Errorf("failed to start frontend %v for volume %v: %v", frontend, c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) VolumeFrontendShutdown() error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.VolumeFrontendShutdown(ctx, &empty.Empty{}); err != nil {
-		return fmt.Errorf("failed to shutdown frontend for volume %v: %v", c.grpcAddress, err)
+		return fmt.Errorf("failed to shutdown frontend for volume %v: %v", c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) ReplicaList() ([]*types.ControllerReplicaInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	reply, err := controllerServiceClient.ReplicaList(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list replicas for volume %v: %v", c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to list replicas for volume %v: %v", c.serviceURL, err)
 	}
 
 	replicas := []*types.ControllerReplicaInfo{}
@@ -239,13 +227,7 @@ func (c *ControllerClient) ReplicaList() ([]*types.ControllerReplicaInfo, error)
 }
 
 func (c *ControllerClient) ReplicaGet(address string) (*types.ControllerReplicaInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -253,20 +235,14 @@ func (c *ControllerClient) ReplicaGet(address string) (*types.ControllerReplicaI
 		Address: address,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get replica %v for volume %v: %v", address, c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to get replica %v for volume %v: %v", address, c.serviceURL, err)
 	}
 
 	return GetControllerReplicaInfo(cr), nil
 }
 
 func (c *ControllerClient) ReplicaCreate(address string, snapshotRequired bool, mode types.Mode) (*types.ControllerReplicaInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -276,59 +252,41 @@ func (c *ControllerClient) ReplicaCreate(address string, snapshotRequired bool, 
 		Mode:             ptypes.ReplicaModeToGRPCReplicaMode(mode),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create replica %v for volume %v: %v", address, c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to create replica %v for volume %v: %v", address, c.serviceURL, err)
 	}
 
 	return GetControllerReplicaInfo(cr), nil
 }
 
 func (c *ControllerClient) ReplicaDelete(address string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.ReplicaDelete(ctx, &ptypes.ReplicaAddress{
 		Address: address,
 	}); err != nil {
-		return fmt.Errorf("failed to delete replica %v for volume %v: %v", address, c.grpcAddress, err)
+		return fmt.Errorf("failed to delete replica %v for volume %v: %v", address, c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) ReplicaUpdate(replica *types.ControllerReplicaInfo) (*types.ControllerReplicaInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	cr, err := controllerServiceClient.ReplicaUpdate(ctx, GetControllerReplica(replica))
 	if err != nil {
-		return nil, fmt.Errorf("failed to update replica %v for volume %v: %v", replica.Address, c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to update replica %v for volume %v: %v", replica.Address, c.serviceURL, err)
 	}
 
 	return GetControllerReplicaInfo(cr), nil
 }
 
 func (c *ControllerClient) ReplicaPrepareRebuild(address string) ([]types.SyncFileInfo, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -336,60 +294,42 @@ func (c *ControllerClient) ReplicaPrepareRebuild(address string) ([]types.SyncFi
 		Address: address,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare rebuilding replica %v for volume %v: %v", address, c.grpcAddress, err)
+		return nil, fmt.Errorf("failed to prepare rebuilding replica %v for volume %v: %v", address, c.serviceURL, err)
 	}
 
 	return GetSyncFileInfoList(reply.SyncFileInfoList), nil
 }
 
 func (c *ControllerClient) ReplicaVerifyRebuild(address string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.ReplicaVerifyRebuild(ctx, &ptypes.ReplicaAddress{
 		Address: address,
 	}); err != nil {
-		return fmt.Errorf("failed to verify rebuilt replica %v for volume %v: %v", address, c.grpcAddress, err)
+		return fmt.Errorf("failed to verify rebuilt replica %v for volume %v: %v", address, c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) JournalList(limit int) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
 	if _, err := controllerServiceClient.JournalList(ctx, &ptypes.JournalListRequest{
 		Limit: int64(limit),
 	}); err != nil {
-		return fmt.Errorf("failed to list journal for volume %v: %v", c.grpcAddress, err)
+		return fmt.Errorf("failed to list journal for volume %v: %v", c.serviceURL, err)
 	}
 
 	return nil
 }
 
 func (c *ControllerClient) VersionDetailGet() (*meta.VersionOutput, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -413,11 +353,12 @@ func (c *ControllerClient) VersionDetailGet() (*meta.VersionOutput, error) {
 }
 
 func (c *ControllerClient) Check() error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
+	conn, err := grpc.Dial(c.serviceURL, grpc.WithInsecure())
 	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
+		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.serviceURL, err)
 	}
 	defer conn.Close()
+	// TODO: JM we can reuse the controller service context connection for the health requests
 	healthCheckClient := healthpb.NewHealthClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
@@ -427,7 +368,7 @@ func (c *ControllerClient) Check() error {
 		Service: "",
 	})
 	if err != nil {
-		return fmt.Errorf("failed to check health for gRPC controller server %v: %v", c.grpcAddress, err)
+		return fmt.Errorf("failed to check health for gRPC controller server %v: %v", c.serviceURL, err)
 	}
 
 	if reply.Status != healthpb.HealthCheckResponse_SERVING {
@@ -438,13 +379,7 @@ func (c *ControllerClient) Check() error {
 }
 
 func (c *ControllerClient) BackupReplicaMappingCreate(backupID string, replicaAddress string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -459,13 +394,7 @@ func (c *ControllerClient) BackupReplicaMappingCreate(backupID string, replicaAd
 }
 
 func (c *ControllerClient) BackupReplicaMappingGet() (map[string]string, error) {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 
@@ -478,13 +407,7 @@ func (c *ControllerClient) BackupReplicaMappingGet() (map[string]string, error) 
 }
 
 func (c *ControllerClient) BackupReplicaMappingDelete(backupID string) error {
-	conn, err := grpc.Dial(c.grpcAddress, grpc.WithInsecure())
-	if err != nil {
-		return fmt.Errorf("cannot connect to ControllerService %v: %v", c.grpcAddress, err)
-	}
-	defer conn.Close()
-	controllerServiceClient := ptypes.NewControllerServiceClient(conn)
-
+	controllerServiceClient := c.getControllerServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceTimeout)
 	defer cancel()
 

--- a/pkg/controller/rebuild.go
+++ b/pkg/controller/rebuild.go
@@ -18,6 +18,7 @@ func getReplicaDisksAndHead(address string) (map[string]types.DiskInfo, string, 
 		return nil, "", fmt.Errorf("Cannot get replica client for %v: %v",
 			address, err)
 	}
+	defer repClient.Close()
 
 	rep, err := repClient.GetReplica()
 	if err != nil {
@@ -135,12 +136,14 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 		return fmt.Errorf("Cannot get replica client for %v: %v",
 			fromReplica.Address, err)
 	}
+	defer fromClient.Close()
 
 	toClient, err := client.NewReplicaClient(toReplica.Address)
 	if err != nil {
 		return fmt.Errorf("Cannot get replica client for %v: %v",
 			toReplica.Address, err)
 	}
+	defer toClient.Close()
 
 	host, port, err := toClient.LaunchReceiver(to)
 	if err != nil {
@@ -235,6 +238,7 @@ func removeExtraDisks(extraDisks map[string]types.DiskInfo, address string) (err
 	if err != nil {
 		return errors.Wrapf(err, "cannot replica client")
 	}
+	defer repClient.Close()
 
 	for disk := range extraDisks {
 		if err = repClient.RemoveDisk(disk, true); err != nil {

--- a/pkg/controller/revert.go
+++ b/pkg/controller/revert.go
@@ -35,6 +35,11 @@ func (c *Controller) Revert(name string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		for _, repClient := range clients {
+			_ = repClient.Close()
+		}
+	}()
 
 	if c.FrontendState() == "up" {
 		return fmt.Errorf("volume frontend enabled, aborting snapshot revert")
@@ -65,6 +70,17 @@ func (c *Controller) Revert(name string) error {
 
 func (c *Controller) clientsAndSnapshot(name string) (map[string]*client.ReplicaClient, string, error) {
 	clients := map[string]*client.ReplicaClient{}
+	var repClient *client.ReplicaClient
+	var err error
+
+	// close all clients in case of error
+	defer func() {
+		if err != nil {
+			for _, repClient := range clients {
+				_ = repClient.Close()
+			}
+		}
+	}()
 
 	for _, replica := range c.replicas {
 		if replica.Mode == types.WO {
@@ -78,17 +94,16 @@ func (c *Controller) clientsAndSnapshot(name string) (map[string]*client.Replica
 			return nil, "", fmt.Errorf("Backend %s does not support revert", replica.Address)
 		}
 
-		repClient, err := client.NewReplicaClient(replica.Address)
+		repClient, err = client.NewReplicaClient(replica.Address)
 		if err != nil {
 			return nil, "", err
 		}
+		clients[replica.Address] = repClient
 
 		_, err = repClient.GetReplica()
 		if err != nil {
 			return nil, "", err
 		}
-
-		clients[replica.Address] = repClient
 	}
 	name = "volume-snap-" + name + ".img"
 

--- a/pkg/controller/revert.go
+++ b/pkg/controller/revert.go
@@ -88,26 +88,6 @@ func (c *Controller) clientsAndSnapshot(name string) (map[string]*client.Replica
 			return nil, "", err
 		}
 
-		/*
-			found := ""
-			for _, snapshot := range rep.Chain {
-				if snapshot == name {
-					found = name
-					break
-				}
-				fullName := "volume-snap-" + name + ".img"
-				if snapshot == fullName {
-					found = fullName
-					break
-				}
-			}
-
-			if found == "" {
-				return nil, "", fmt.Errorf("Failed to find snapshot %s on %s", name, replica)
-			}
-
-			name = found
-		*/
 		clients[replica.Address] = repClient
 	}
 	name = "volume-snap-" + name + ".img"

--- a/pkg/replica/client/client.go
+++ b/pkg/replica/client/client.go
@@ -224,7 +224,7 @@ func (c *ReplicaClient) OpenReplica() error {
 	return nil
 }
 
-func (c *ReplicaClient) Close() error {
+func (c *ReplicaClient) CloseReplica() error {
 	replicaServiceClient := c.getReplicaServiceClient()
 	ctx, cancel := context.WithTimeout(context.Background(), GRPCServiceCommonTimeout)
 	defer cancel()

--- a/pkg/replica/client/client.go
+++ b/pkg/replica/client/client.go
@@ -103,15 +103,15 @@ func GetReplicaInfo(r *ptypes.Replica) *types.ReplicaInfo {
 	return replicaInfo
 }
 
-func (c *ReplicaClient) syncFileInfoListToSyncAgentGRPCFormat(list []types.SyncFileInfo) []*ptypes.SyncFileInfo {
+func syncFileInfoListToSyncAgentGRPCFormat(list []types.SyncFileInfo) []*ptypes.SyncFileInfo {
 	res := []*ptypes.SyncFileInfo{}
 	for _, info := range list {
-		res = append(res, c.syncFileInfoToSyncAgentGRPCFormat(info))
+		res = append(res, syncFileInfoToSyncAgentGRPCFormat(info))
 	}
 	return res
 }
 
-func (c *ReplicaClient) syncFileInfoToSyncAgentGRPCFormat(info types.SyncFileInfo) *ptypes.SyncFileInfo {
+func syncFileInfoToSyncAgentGRPCFormat(info types.SyncFileInfo) *ptypes.SyncFileInfo {
 	return &ptypes.SyncFileInfo{
 		FromFileName: info.FromFileName,
 		ToFileName:   info.ToFileName,
@@ -450,7 +450,7 @@ func (c *ReplicaClient) SyncFiles(fromAddress string, list []types.SyncFileInfo)
 	if _, err := syncAgentServiceClient.FilesSync(ctx, &ptypes.FilesSyncRequest{
 		FromAddress:      fromAddress,
 		ToHost:           c.host,
-		SyncFileInfoList: c.syncFileInfoListToSyncAgentGRPCFormat(list),
+		SyncFileInfoList: syncFileInfoListToSyncAgentGRPCFormat(list),
 	}); err != nil {
 		return fmt.Errorf("failed to sync files %+v from %v: %v", list, fromAddress, err)
 	}

--- a/pkg/sync/backup.go
+++ b/pkg/sync/backup.go
@@ -114,6 +114,7 @@ func (t *Task) createBackup(replicaInController *types.ControllerReplicaInfo, sn
 	return info, nil
 }
 
+// FetchBackupStatus instance method is @deprecated use the free function FetchBackupStatus instead
 func (t *Task) FetchBackupStatus(backupID string, replicaAddr string) (*BackupStatusInfo, error) {
 	repClient, err := replicaClient.NewReplicaClient(replicaAddr)
 	if err != nil {
@@ -139,6 +140,24 @@ func (t *Task) FetchBackupStatus(backupID string, replicaAddr string) (*BackupSt
 	}
 
 	return info, nil
+}
+
+func FetchBackupStatus(client *replicaClient.ReplicaClient, backupID string, replicaAddr string) (*BackupStatusInfo, error) {
+	bs, err := client.BackupStatus(backupID)
+	if err != nil {
+		return &BackupStatusInfo{
+			Error: fmt.Sprintf("Failed to get backup status on %s for %v: %v", replicaAddr, backupID, err),
+		}, nil
+	}
+
+	return &BackupStatusInfo{
+		Progress:       int(bs.Progress),
+		BackupURL:      bs.BackupUrl,
+		Error:          bs.Error,
+		SnapshotName:   bs.SnapshotName,
+		State:          bs.State,
+		ReplicaAddress: replicaAddr,
+	}, nil
 }
 
 func (t *Task) RestoreBackup(backup string, credential map[string]string) error {

--- a/pkg/sync/backup.go
+++ b/pkg/sync/backup.go
@@ -84,6 +84,7 @@ func (t *Task) createBackup(replicaInController *types.ControllerReplicaInfo, sn
 	if err != nil {
 		return nil, err
 	}
+	defer repClient.Close()
 
 	rep, err := repClient.GetReplica()
 	if err != nil {
@@ -119,6 +120,7 @@ func (t *Task) FetchBackupStatus(backupID string, replicaAddr string) (*BackupSt
 		logrus.Errorf("Cannot create a replica client for IP[%v]: %v", replicaAddr, err)
 		return nil, err
 	}
+	defer repClient.Close()
 
 	bs, err := repClient.BackupStatus(backupID)
 	if err != nil {
@@ -271,6 +273,8 @@ func (t *Task) restoreBackup(replicaInController *types.ControllerReplicaInfo, b
 	if err != nil {
 		return err
 	}
+	defer repClient.Close()
+
 	if err := repClient.RestoreBackup(backup, snapshotFile, credential); err != nil {
 		return err
 	}
@@ -295,15 +299,22 @@ func (t *Task) Reset() error {
 		}
 	}
 
+	var clients []*replicaClient.ReplicaClient
+	defer func() {
+		for _, client := range clients {
+			_ = client.Close()
+		}
+	}()
+
 	for _, replica := range replicas {
 		repClient, err := replicaClient.NewReplicaClient(replica.Address)
 		if err != nil {
 			logrus.Errorf("Failed to get a replica client: %v for %v", err, replica.Address)
 			return err
 		}
+		clients = append(clients, repClient)
 
 		logrus.Infof("Performing sync-agent-server-reset for replica %s", replica.Address)
-
 		if err := repClient.Reset(); err != nil {
 			logrus.Errorf("Failed Resetting restore status for replica %s", replica.Address)
 			return err
@@ -321,14 +332,24 @@ func (t *Task) RestoreStatus() (map[string]*RestoreStatus, error) {
 		return nil, err
 	}
 
+	// clean up clients after processing
+	var clients []*replicaClient.ReplicaClient
+	defer func() {
+		for _, client := range clients {
+			_ = client.Close()
+		}
+	}()
+
 	for _, replica := range replicas {
 		if replica.Mode == types.ERR {
 			continue
 		}
+
 		repClient, err := replicaClient.NewReplicaClient(replica.Address)
 		if err != nil {
 			return nil, err
 		}
+		clients = append(clients, repClient)
 
 		rs, err := repClient.RestoreStatus()
 		if err != nil {

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -403,6 +403,7 @@ func (s *SyncAgentServer) FilesSync(ctx context.Context, req *ptypes.FilesSyncRe
 	if err != nil {
 		return nil, err
 	}
+	defer fromClient.Close()
 
 	var ops sparserest.SyncFileOperations
 	fileStub := &sparserest.SyncFileStub{}

--- a/version.go
+++ b/version.go
@@ -37,8 +37,12 @@ func version(c *cli.Context) error {
 	v := VersionOutput{ClientVersion: &clientVersion}
 
 	if !c.Bool("client-only") {
-		url := c.GlobalString("url")
-		controllerClient := client.NewControllerClient(url)
+		controllerClient, err := client.NewControllerClient(c.GlobalString("url"))
+		if err != nil {
+			return err
+		}
+		defer controllerClient.Close()
+
 		version, err := controllerClient.VersionDetailGet()
 		if err != nil {
 			return err


### PR DESCRIPTION
This enables GRPC connection reuse for the Controller/Replica clients

We also initialize the clients as part of the Constructors to deal with incorrect addresses for the example
I retained the prior behavior of the background lazy connection, so connection establishment errors would still
be reported as part of the first grpc call.

With this code structure we have the ability to add retry loops for transient errors, i.e. subconnection in failures.
I will create an EPIC for grpc communication improvemets so we can track this further.

I only implement the Task change for  the BackupStatus retrieval, the others can be just as easily implemented after this PR.
We should consider the Task struct as deprecated and over time turn the instance methods into free functions.
Then the caller can pass the appropriatly required clients.

longhorn/longhorn#2818