### PR TITLE
2818 further socket usage optimizations

### DIFF
--- a/pkg/util/once.go
+++ b/pkg/util/once.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Once is modification of sync.Once to only set done once Do has run f() once successfully
+// A Once must not be copied after first use.
+type Once struct {
+	// done is set only when Do has run f() one time successfully
+	done uint32
+	m    sync.Mutex
+}
+
+// Do execute f() only if it has never been run successfully before
+// if f() encounters an error it will be returned to the caller
+func (o *Once) Do(f func() error) error {
+	if atomic.LoadUint32(&o.done) == 1 { //fast path
+		return nil
+	}
+
+	return o.doSlow(f)
+}
+
+func (o *Once) doSlow(f func() error) error {
+	o.m.Lock()
+	defer o.m.Unlock()
+
+	var err error
+	if o.done == 0 {
+		if err = f(); err == nil {
+			defer atomic.StoreUint32(&o.done, 1)
+		}
+	}
+	return err
+}

--- a/pkg/util/once_test.go
+++ b/pkg/util/once_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"fmt"
+	. "gopkg.in/check.v1"
+	"sync"
+)
+
+func (s *TestSuite) TestOnce(c *C) {
+	var counter int
+	var once Once
+	f := func() error {
+		if counter == 0 {
+			// this is safe since we are inside of a lock while executing f
+			// and f is the only thing accessing counter
+			counter++
+			return fmt.Errorf("first call of once failed")
+		}
+		return nil
+	}
+
+	err := once.Do(f)
+	c.Assert(err, NotNil)
+
+	err = once.Do(f)
+	c.Assert(err, IsNil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Assert(once.Do(f), IsNil)
+			c.Assert(counter, Equals, 1)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Lazily initialize the replica clients for replica/sync service

This is to optimize the connection count for the longhorn-manager engine
monitor loop, in a single loop the monitor executes the engine binary 8
times this leads to a total connection count of `f() = 8e + 6 * 2r = 20`
for a volume with 1 replica.

Since all the calls the monitor makes only require either the replica or
the sync client, we can reduce this further with this optimization to
`g() = 8e + 6r = 14` per monitor loop.

The monitor loop executes `60/5 = 12` times per minute, so our total 
connections per minute are reduced from **240** to **168**. For volume with 3 
replicas we end up with **312** connection per minute.

No further optimization on this end is possible, the next required task
is removal of the direct engine binary invocations by the longhorn-manager.
This will reduce the connection counts to `h() = 1e + 2*r` which as one
can see would lead to the desired behavior for each volume of 1 engine connection 
and 2 connections per replica (replica / sync).

longhorn/longhorn#2818

Signed-off-by: Joshua Moody <joshua.moody@suse.com>