### PR TITLE
Bump up the CLI API version to 6

### DIFF
--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -2,7 +2,7 @@ package meta
 
 const (
 	// CLIAPIVersion used to communicate with user e.g. longhorn-manager
-	CLIAPIVersion    = 5
+	CLIAPIVersion    = 6
 	CLIAPIMinVersion = 3
 
 	// ControllerAPIVersion used to communicate with instance-manager


### PR DESCRIPTION
Bump up the CLI API version because of adding new `SnapshotCloneCmd()` and `SnapshotCloneStatusCmd()` CLIs

longhorn/longhorn#1815