### PR TITLE
Fix purge status percentage

### DIFF
--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -1106,12 +1106,13 @@ func (s *SyncAgentServer) purgeSnapshots() (err error) {
 			snapshot = info.Parent
 		}
 		// Update snapshotInfo in case some nodes have been removed
-		snapshotsInfo, _, err = getSnapshotsInfo(replicaClient)
+		snapshotsInfo, markedRemoved, err = getSnapshotsInfo(replicaClient)
 		if err != nil {
 			return err
 		}
 		s.PurgeStatus.Lock()
-		s.PurgeStatus.Progress = int(float32(removed) / float32(markedRemoved) * 100)
+		s.PurgeStatus.total = markedRemoved + removed
+		s.PurgeStatus.Progress = int(float32(removed) / float32(s.PurgeStatus.total) * 100)
 		s.PurgeStatus.Unlock()
 	}
 


### PR DESCRIPTION
This adds new snapshots marked to be removed while performing the purge
to the total number of snapshots to purge so that the percentage does
not exceed 100%.

https://github.com/longhorn/longhorn/issues/2892

Signed-off-by: Keith Lucas <keith.lucas@suse.com>