### PR TITLE
nfs: only return coalesce error when last NFSv4 version fails to mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,5 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/cheggaaa/pb.v2 v2.0.0-20190301131520-f907f6f5dd81
 )
+
+replace github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665 => github.com/derekbit/backupstore v0.0.0-20211029120756-3ed8c0e7df1c

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/derekbit/backupstore v0.0.0-20211029120756-3ed8c0e7df1c h1:6ylzoqQjWMMf0WRrqNi3O7aaXDpG5JLZzdqLAsrZEBg=
+github.com/derekbit/backupstore v0.0.0-20211029120756-3ed8c0e7df1c/go.mod h1:FUjQNWqcEXSFIrQpfWLxFFHXywk14mM5w9TNRuBrKzY=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/honestbee/jobq
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
-# github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665
+# github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665 => github.com/derekbit/backupstore v0.0.0-20211029120756-3ed8c0e7df1c
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
(1) Only return coalesce error when last NFSv4 version fails to mount.
(2) Remove NFSv3 try mount and umount from defer function.

Signed-off-by: Derek Su <derek.su@suse.com>