### PR TITLE
nfs: only return coalesce error when last NFSv4 version fails to mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/longhorn/backupstore v0.0.0-20211103032928-e0553c0a74c8
+	github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 	github.com/longhorn/sparse-tools v0.0.0-20210729195155-a0fb4226a960
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/longhorn/backupstore v0.0.0-20211103032928-e0553c0a74c8 h1:/oqQ5DPInFFDO2w/lBvUIgiNOk9hJn9kNMvSjWeZvOs=
-github.com/longhorn/backupstore v0.0.0-20211103032928-e0553c0a74c8/go.mod h1:bgqye7PKUlZNkFo1ElWd9a2P8b5psVthBiF4uxA4LKw=
+github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba h1:pChpuTzNmNaj+pi4EDJVxUSrcqyWXM5joLJT5Vty1PI=
+github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba/go.mod h1:bgqye7PKUlZNkFo1ElWd9a2P8b5psVthBiF4uxA4LKw=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,7 @@ github.com/gorilla/websocket
 github.com/honestbee/jobq
 # github.com/jmespath/go-jmespath v0.3.0
 github.com/jmespath/go-jmespath
-# github.com/longhorn/backupstore v0.0.0-20211103032928-e0553c0a74c8
+# github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
This PR is related to backupstore.

(1) Only return coalesce error when last NFSv4 version fails to mount.
(2) Remove NFSv3 try mount and umount from defer function.

Signed-off-by: Derek Su <derek.su@suse.com>