### PR TITLE
nfs: only return coalesce error when last NFSv4 version fails to mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665
+	github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba
 	github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e
 	github.com/longhorn/sparse-tools v0.0.0-20210729195155-a0fb4226a960
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665 h1:71DO2ty1iibnLyvjp1E8pBkmFkzfW9u45TcAbE9Jrog=
-github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665/go.mod h1:FUjQNWqcEXSFIrQpfWLxFFHXywk14mM5w9TNRuBrKzY=
+github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba h1:pChpuTzNmNaj+pi4EDJVxUSrcqyWXM5joLJT5Vty1PI=
+github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba/go.mod h1:bgqye7PKUlZNkFo1ElWd9a2P8b5psVthBiF4uxA4LKw=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e h1:hz4quJkaJWDo+xW+G6wTF6d6/95QvJ+o2D0+bB/tJ1U=
 github.com/longhorn/go-iscsi-helper v0.0.0-20210330030558-49a327fb024e/go.mod h1:9z/y9glKmWEdV50tjlUPxFwi1goQfIrrsoZbnMyIZbY=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/gorilla/websocket
 github.com/honestbee/jobq
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
-# github.com/longhorn/backupstore v0.0.0-20210908163358-43c9d3298665
+# github.com/longhorn/backupstore v0.0.0-20211103081249-ebc3c90895ba
 github.com/longhorn/backupstore
 github.com/longhorn/backupstore/cmd
 github.com/longhorn/backupstore/fsops


### PR DESCRIPTION
(1) Only return coalesce error when last NFSv4 version fails to mount.
(2) Remove NFSv3 try mount/umount from defer function.

Signed-off-by: Derek Su <derek.su@suse.com>