### PR TITLE
Check that array isn't empty before accessing

### DIFF
--- a/pkg/controller/rebuild.go
+++ b/pkg/controller/rebuild.go
@@ -26,6 +26,10 @@ func getReplicaDisksAndHead(address string) (map[string]types.DiskInfo, string, 
 			address, err)
 	}
 
+	if len(rep.Chain) == 0 {
+		return nil, "", fmt.Errorf("replica on %v does not have any non-removed disks", address)
+	}
+
 	disks := map[string]types.DiskInfo{}
 	head := rep.Chain[0]
 	for diskName, info := range rep.Disks {


### PR DESCRIPTION
Prevent longhorn-engine from crashing because it attempts to access the first element in an array whose length is zero.

https://github.com/longhorn/longhorn/issues/3822

Signed-off-by: Keith Lucas <keith.lucas@suse.com>