### PR TITLE
Fix bug forget to remove the snapshot from r.diskChildrenMap when removing snapshot

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -492,6 +492,7 @@ func (r *Replica) removeDiskNode(name string, force bool) error {
 		return err
 	}
 	delete(r.diskData, name)
+	delete(r.diskChildrenMap, name)
 
 	index := r.findDisk(name)
 	if index <= 0 {


### PR DESCRIPTION
Since we forgot to remove the snapshot from the r.diskChildrenMap when removing the snapshot, when the user creates snapshot with the same name again, the children map of the snapshot is messed up

longhorn/longhorn#3883
