### PR TITLE
[Backport v1.2.5] Fix bug forget to remove the snapshot from r.diskChildrenMap when removing snapshot

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -493,6 +493,7 @@ func (r *Replica) removeDiskNode(name string, force bool) error {
 		return err
 	}
 	delete(r.diskData, name)
+	delete(r.diskChildrenMap, name)
 
 	index := r.findDisk(name)
 	if index <= 0 {


### PR DESCRIPTION
longhorn/longhorn#3883
longhorn/longhorn#3911