### PR TITLE
add format duplicate address

### DIFF
--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -593,6 +593,14 @@ func (c *Controller) Start(addresses ...string) error {
 		return nil
 	}
 
+	checkDuplicate := map[string]struct{}{}
+	for _, address := range addresses {
+		if _, exist := checkDuplicate[address]; exist {
+			return fmt.Errorf("invalid ReplicaAddress: duplicate replica addresses %s", address)
+		}
+		checkDuplicate[address] = struct{}{}
+	}
+
 	if len(c.replicas) > 0 {
 		return nil
 	}


### PR DESCRIPTION
If longhorn use the setting of storage-network, and the second
network is contronllerd by ovs-cni, there is three
instance-managers of replica, and the instance-manager of replica
may have the same storage ip address.

longhorn/longhorn#4282

Signed-off-by: 王一知 <wangyizhi@inspur.com>