### PR TITLE
Mark the replica ERR if its volume.meta is in invalid state

### DIFF
--- a/pkg/backend/file/file.go
+++ b/pkg/backend/file/file.go
@@ -117,6 +117,10 @@ func (ff *Factory) Create(address string) (types.Backend, error) {
 	return &Wrapper{file}, nil
 }
 
+func (f *Wrapper) GetState() (string, error) {
+	return "open", nil
+}
+
 func (f *Wrapper) GetMonitorChannel() types.MonitorChannel {
 	return nil
 }

--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -219,6 +219,15 @@ func (r *Remote) GetRevisionCounter() (int64, error) {
 	return 0, fmt.Errorf("invalid state %v for getting revision counter", replicaInfo.State)
 }
 
+func (r *Remote) GetState() (string, error) {
+	replicaInfo, err := r.info()
+	if err != nil {
+		return "", err
+	}
+
+	return replicaInfo.State, nil
+}
+
 func (r *Remote) info() (*types.ReplicaInfo, error) {
 	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure())
 	if err != nil {

--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -466,7 +466,7 @@ func (c *Controller) StartFrontend(frontend string) error {
 // controller, and mark unmatch replica to ERR.
 func (c *Controller) checkReplicaRevCounterSettingMatch() error {
 	for _, r := range c.replicas {
-		if r.Mode == "ERR" {
+		if r.Mode == types.ERR {
 			continue
 		}
 		revCounterDisabled, err := c.backend.backends[r.Address].backend.IsRevisionCounterDisabled()
@@ -489,7 +489,7 @@ func (c *Controller) salvageRevisionCounterDisabledReplicas() error {
 	replicaCandidates := make(map[types.Replica]types.ReplicaSalvageInfo)
 	var lastModifyTime int64
 	for _, r := range c.replicas {
-		if r.Mode == "ERR" {
+		if r.Mode == types.ERR {
 			continue
 		}
 		repLastModifyTime, err := c.backend.backends[r.Address].backend.GetLastModifyTime()

--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -14,6 +14,7 @@ import (
 
 	iutil "github.com/longhorn/go-iscsi-helper/util"
 
+	"github.com/longhorn/longhorn-engine/pkg/replica"
 	"github.com/longhorn/longhorn-engine/pkg/types"
 	"github.com/longhorn/longhorn-engine/pkg/util"
 )
@@ -577,6 +578,23 @@ func (c *Controller) checkReplicasRevisionCounter() error {
 	return nil
 }
 
+func isReplicaInInvalidState(state string) bool {
+	return state != string(replica.Open) && state != string(replica.Dirty)
+}
+
+func checkDeuplicteAddress(addresses ...string) error {
+	checkDuplicate := map[string]struct{}{}
+
+	for _, address := range addresses {
+		if _, exist := checkDuplicate[address]; exist {
+			return fmt.Errorf("invalid ReplicaAddress: duplicate replica addresses %s", address)
+		}
+		checkDuplicate[address] = struct{}{}
+	}
+
+	return nil
+}
+
 func (c *Controller) Start(addresses ...string) error {
 	c.Lock()
 	defer c.Unlock()
@@ -585,12 +603,8 @@ func (c *Controller) Start(addresses ...string) error {
 		return nil
 	}
 
-	checkDuplicate := map[string]struct{}{}
-	for _, address := range addresses {
-		if _, exist := checkDuplicate[address]; exist {
-			return fmt.Errorf("invalid ReplicaAddress: duplicate replica addresses %s", address)
-		}
-		checkDuplicate[address] = struct{}{}
+	if err := checkDeuplicteAddress(addresses...); err != nil {
+		return err
 	}
 
 	if len(c.replicas) > 0 {
@@ -618,6 +632,16 @@ func (c *Controller) Start(addresses ...string) error {
 			logrus.Warnf("failed to get the sector size from the backend address %v: %v", address, err)
 			continue
 		}
+		state, err := newBackend.GetState()
+		if err != nil {
+			logrus.Warnf("failed to get the state from the backend address %v: %v", address, err)
+			continue
+		}
+		if isReplicaInInvalidState(state) {
+			logrus.Warnf("backend %v is in the invalid state %v", address, state)
+			continue
+		}
+
 		availableBackends[address] = newBackend
 
 		if first {

--- a/pkg/dataconn/client.go
+++ b/pkg/dataconn/client.go
@@ -244,7 +244,7 @@ func (c *Client) read() {
 	for {
 		msg, err := c.wire.Read()
 		if err != nil {
-			logrus.Errorf("Error reading from wire: %v", err)
+			logrus.Errorf("Error reading from wire %v: %v", c.peerAddr, err)
 			c.responses <- &Message{
 				transportErr: err,
 			}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -563,12 +563,12 @@ func (t *Task) getTransferClients(address string) (*replicaClient.ReplicaClient,
 	if fromClient, fromAddress, err = t.getFromReplicaClientForTransfer(); err != nil {
 		return nil, nil, "", "", err
 	}
-	logrus.Infof("Using replica %s as the source for rebuild ", fromAddress)
+	logrus.Infof("Using replica %s as the source for rebuild", fromAddress)
 
 	if toClient, toAddress, err = t.getToReplicaClientForTransfer(address); err != nil {
 		return nil, nil, "", "", err
 	}
-	logrus.Infof("Using replica %s as the target for rebuild ", toAddress)
+	logrus.Infof("Using replica %s as the target for rebuild", toAddress)
 
 	return fromClient, toClient, fromAddress, toAddress, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -60,6 +60,7 @@ type Backend interface {
 	RemainSnapshots() (int, error)
 	GetRevisionCounter() (int64, error)
 	SetRevisionCounter(counter int64) error
+	GetState() (string, error)
 	GetMonitorChannel() MonitorChannel
 	StopMonitoring()
 	IsRevisionCounterDisabled() (bool, error)


### PR DESCRIPTION
If there is any available replica, mark the replicas ERR if their volume.meta are in invalid state.

https://github.com/longhorn/longhorn/issues/4212

Signed-off-by: Derek Su <derek.su@suse.com>