### PR TITLE
Tagging netgo to be used while compiling with cgo 

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,7 +6,7 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-go build -ldflags \
+go build -tags netgo -ldflags \
 	"-X main.Version=$VERSION \
 	-X main.GitCommit=$GITCOMMIT \
 	-X main.BuildDate=$BUILDDATE \


### PR DESCRIPTION
~Implements suggestion in https://github.com/longhorn/longhorn/issues/4415#issuecomment-1214885963 and disable CGO here too like it was done in longhorn-manager by https://github.com/longhorn/longhorn-manager/pull/61~

Looks that longhorn-engine needs CGO so switched to alternative solution proposed in https://github.com/longhorn/longhorn/issues/1768#issuecomment-690778513