### PR TITLE
Serialize the write IO requsts if the IOs are not aligned with 4KiB and the sizes are not a miltiple of 4KiB

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,6 +33,8 @@ var (
 	cmdTimeout = time.Minute // one minute by default
 
 	HostProc = "/host/proc"
+
+	DefaultBlockSize = int64(4096)
 )
 
 const (


### PR DESCRIPTION
To fix the potential data corruption caused by io race condition in existing volumes with data or metadata block size less than 4KiB, serialize the write IO requsts if the IOs are not aligned with 4KiB and the sizes are not a miltiple of 4KiB.

[Longhorn 4619](https://github.com/longhorn/longhorn/issues/4619)

Signed-off-by: Derek Su <derek.su@suse.com>