### PR TITLE
[BACKPORT][v1.3.2] Reorganize volume, replica and backing image sector sizes

### DIFF
--- a/app/cmd/replica.go
+++ b/app/cmd/replica.go
@@ -82,7 +82,7 @@ func startReplica(c *cli.Context) error {
 
 	disableRevCounter := c.Bool("disableRevCounter")
 
-	s := replica.NewServer(dir, backingFile, 512, disableRevCounter)
+	s := replica.NewServer(dir, backingFile, util.ReplicaSectorSize, disableRevCounter)
 
 	address := c.String("listen")
 

--- a/pkg/backingfile/backingfile.go
+++ b/pkg/backingfile/backingfile.go
@@ -16,8 +16,6 @@ import (
 	"github.com/longhorn/longhorn-engine/pkg/util"
 )
 
-const defaultSectorSize = 512
-
 type BackingFile struct {
 	Size       int64
 	SectorSize int64
@@ -102,14 +100,14 @@ func OpenBackingFile(file string) (*BackingFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	if size%defaultSectorSize != 0 {
-		return nil, fmt.Errorf("the backing file size %v should be a multiple of 512 bytes since Longhorn uses directIO by default", size)
+	if size%util.BackingImageSectorSize != 0 {
+		return nil, fmt.Errorf("the backing file size %v should be a multiple of %v bytes since Longhorn uses directIO by default", size, util.BackingImageSectorSize)
 	}
 
 	return &BackingFile{
 		Path:       file,
 		Disk:       f,
 		Size:       size,
-		SectorSize: defaultSectorSize,
+		SectorSize: util.BackingImageSectorSize,
 	}, nil
 }

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -30,7 +30,6 @@ const (
 	metadataSuffix     = ".meta"
 	imgSuffix          = ".img"
 	volumeMetaData     = "volume.meta"
-	defaultSectorSize  = 4096
 	headPrefix         = "volume-head-"
 	headSuffix         = ".img"
 	headName           = headPrefix + "%03d" + headSuffix
@@ -159,7 +158,7 @@ func New(size, sectorSize int64, dir string, backingFile *backingfile.BackingFil
 
 func NewReadOnly(dir, head string, backingFile *backingfile.BackingFile) (*Replica, error) {
 	// size and sectorSize don't matter because they will be read from metadata
-	return construct(true, 0, 512, dir, head, backingFile, false)
+	return construct(true, 0, util.ReplicaSectorSize, dir, head, backingFile, false)
 }
 
 func construct(readonly bool, size, sectorSize int64, dir, head string, backingFile *backingfile.BackingFile, disableRevCounter bool) (*Replica, error) {
@@ -181,7 +180,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	}
 	r.info.Size = size
 	r.info.SectorSize = sectorSize
-	r.volume.sectorSize = defaultSectorSize
+	r.volume.sectorSize = util.VolumeSectorSize
 
 	// Scan all the disks to build the disk map
 	exists, err := r.readMetadata()
@@ -205,7 +204,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	// Reference r.info.Size because it may have changed from reading
 	// metadata
 	locationSize := r.info.Size / r.volume.sectorSize
-	if size%defaultSectorSize != 0 {
+	if size%util.VolumeSectorSize != 0 {
 		locationSize++
 	}
 	r.volume.location = make([]byte, locationSize)
@@ -1027,7 +1026,7 @@ func (r *Replica) readMetadata() (bool, error) {
 			if err := r.unmarshalFile(file.Name(), &r.info); err != nil {
 				return false, err
 			}
-			r.volume.sectorSize = defaultSectorSize
+			r.volume.sectorSize = util.VolumeSectorSize
 			r.volume.size = r.info.Size
 		} else if strings.HasSuffix(file.Name(), metadataSuffix) {
 			if err := r.readDiskData(file.Name()); err != nil {

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -25,7 +25,7 @@ type Server struct {
 	sync.RWMutex
 	r                       *Replica
 	dir                     string
-	defaultSectorSize       int64
+	sectorSize              int64
 	backing                 *backingfile.BackingFile
 	revisionCounterDisabled bool
 }
@@ -34,7 +34,7 @@ func NewServer(dir string, backing *backingfile.BackingFile, sectorSize int64, d
 	return &Server{
 		dir:                     dir,
 		backing:                 backing,
-		defaultSectorSize:       sectorSize,
+		sectorSize:              sectorSize,
 		revisionCounterDisabled: disableRevCounter,
 	}
 }
@@ -43,7 +43,7 @@ func (s *Server) getSectorSize() int64 {
 	if s.backing != nil && s.backing.SectorSize > 0 {
 		return s.backing.SectorSize
 	}
-	return s.defaultSectorSize
+	return s.sectorSize
 }
 
 func (s *Server) Create(size int64) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -30,12 +30,14 @@ var (
 	MaximumVolumeNameSize = 64
 	validVolumeName       = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
 
-	cmdTimeout = time.Minute // one minute by default
-
 	HostProc = "/host/proc"
 )
 
 const (
+	VolumeSectorSize       = 4096
+	ReplicaSectorSize      = 512
+	BackingImageSectorSize = 512
+
 	BlockSizeLinux = 512
 )
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/4599
https://github.com/longhorn/longhorn/issues/4635

Signed-off-by: Derek Su <derek.su@suse.com>
(cherry picked from commit 1d5d3c94c572651c546d29dc074c2a4608adc283)