### PR TITLE
fix(qemu-img): Require -F with -b backing image

### DIFF
--- a/app/cmd/restore_to_file.go
+++ b/app/cmd/restore_to_file.go
@@ -240,7 +240,7 @@ func MergeSnapshotsToBackingFile(snapFilepath, backingFilepath string) error {
 
 func rebaseSnapshot(snapFilepath, backingFilepath string) error {
 	logrus.Infof("Start rebaseSnapshot %s -> %s", snapFilepath, backingFilepath)
-	_, err := iutil.ExecuteWithoutTimeout(QEMUImageBinary, []string{"rebase", "-u", "-b", backingFilepath, snapFilepath})
+	_, err := iutil.ExecuteWithoutTimeout(QEMUImageBinary, []string{"rebase", "-u", "-b", backingFilepath, "-F", DefaultOutputFormat, snapFilepath})
 	if err != nil {
 		return errors.Wrapf(err, "failed rebaseSnapshot %s -> %s", snapFilepath, backingFilepath)
 	}


### PR DESCRIPTION
New version of qemu-img requires `-F` flag for backing file format when we upgrade the base image version SLES from 15.3 to 15.4

https://gitlab.com/qemu-project/qemu/-/commit/497a30dbb065937d67f6c43af6dd78492e1d6f6d

longhorn/longhorn#4632

Signed-off-by: James Lu <james.lu@suse.com>