### PR TITLE
[BACKPORT][v1.2.6] fix(qemu-img): Require -F with -b backing image

### DIFF
--- a/app/cmd/restore_to_file.go
+++ b/app/cmd/restore_to_file.go
@@ -240,7 +240,7 @@ func MergeSnapshotsToBackingFile(snapFilepath, backingFilepath string) error {
 
 func rebaseSnapshot(snapFilepath, backingFilepath string) error {
 	logrus.Infof("Start rebaseSnapshot %s -> %s", snapFilepath, backingFilepath)
-	_, err := iutil.ExecuteWithoutTimeout(QEMUImageBinary, []string{"rebase", "-u", "-b", backingFilepath, snapFilepath})
+	_, err := iutil.ExecuteWithoutTimeout(QEMUImageBinary, []string{"rebase", "-u", "-b", backingFilepath, "-F", DefaultOutputFormat, snapFilepath})
 	if err != nil {
 		return errors.Wrapf(err, "failed rebaseSnapshot %s -> %s", snapFilepath, backingFilepath)
 	}


### PR DESCRIPTION
New version of qemu-img requires `-F` flag for backing file format when we upgrade the base image version SLES from 15.3 to 15.4

longhorn/longhorn#4716

Signed-off-by: James Lu <james.lu@suse.com>