### PR TITLE
Unify the format of returned error messages

### DIFF
--- a/app/cmd/backup.go
+++ b/app/cmd/backup.go
@@ -100,7 +100,7 @@ func getReplicaModeMap(replicas []*types.ControllerReplicaInfo) map[string]types
 func checkBackupStatus(c *cli.Context) error {
 	backupID := c.Args().First()
 	if backupID == "" {
-		return fmt.Errorf("Missing required parameter backupID")
+		return fmt.Errorf("missing required parameter backupID")
 	}
 
 	controllerClient, err := getControllerClient(c)
@@ -111,7 +111,7 @@ func checkBackupStatus(c *cli.Context) error {
 
 	replicas, err := controllerClient.ReplicaList()
 	if err != nil {
-		return fmt.Errorf("failed to get replica list: %v", err)
+		return errors.Wrap(err, "failed to get replica list")
 	}
 
 	replicaAddress := c.String("replica")
@@ -137,18 +137,18 @@ func checkBackupStatus(c *cli.Context) error {
 		}
 	}
 	if replicaAddress == "" {
-		return fmt.Errorf("Cannot find a replica which has the corresponding backup %s", backupID)
+		return fmt.Errorf("cannot find a replica which has the corresponding backup %s", backupID)
 	}
 
 	replicaModeMap := getReplicaModeMap(replicas)
 	if mode := replicaModeMap[replicaAddress]; mode != types.RW {
-		return fmt.Errorf("Failed to get backup status on %s for %v: %v",
+		return fmt.Errorf("failed to get backup status on %s for %v: %v",
 			replicaAddress, backupID, "unknown replica")
 	}
 
 	repClient, err := replicaClient.NewReplicaClient(replicaAddress)
 	if err != nil {
-		logrus.Errorf("Cannot create a replica client for IP[%v]: %v", replicaAddress, err)
+		logrus.Errorf("cannot create a replica client for IP[%v]: %v", replicaAddress, err)
 		return err
 	}
 	defer repClient.Close()
@@ -205,12 +205,12 @@ func RestoreStatusCmd() cli.Command {
 func createBackup(c *cli.Context) error {
 	dest := c.String("dest")
 	if dest == "" {
-		return fmt.Errorf("Missing required parameter --dest")
+		return fmt.Errorf("missing required parameter --dest")
 	}
 
 	snapshot := c.Args().First()
 	if snapshot == "" {
-		return fmt.Errorf("Missing required parameter snapshot")
+		return fmt.Errorf("missing required parameter snapshot")
 	}
 
 	biName := c.String("backing-image-name")
@@ -263,7 +263,7 @@ func restoreBackup(c *cli.Context) error {
 
 	backup := c.Args().First()
 	if backup == "" {
-		return fmt.Errorf("Missing required parameter backup")
+		return fmt.Errorf("missing required parameter backup")
 	}
 	backupURL := util.UnescapeURL(backup)
 

--- a/app/cmd/controller.go
+++ b/app/cmd/controller.go
@@ -120,7 +120,7 @@ func startController(c *cli.Context) error {
 	if frontendName != "" {
 		f, ok := controller.Frontends[frontendName]
 		if !ok {
-			return fmt.Errorf("Failed to find frontend: %s", frontendName)
+			return fmt.Errorf("failed to find frontend: %s", frontendName)
 		}
 		frontend = f
 	}

--- a/app/cmd/restore_to_file.go
+++ b/app/cmd/restore_to_file.go
@@ -111,12 +111,12 @@ func restore(url string) error {
 func restoreToFile(c *cli.Context) error {
 	outputFormat := c.String("output-format")
 	if !outputFormatSupported(outputFormat) {
-		return fmt.Errorf("Unsupported output image format: %s", outputFormat)
+		return fmt.Errorf("unsupported output image format: %s", outputFormat)
 	}
 
 	backupURL := c.Args().First()
 	if backupURL == "" {
-		return fmt.Errorf("Missing the first argument, it should be backup-url")
+		return fmt.Errorf("missing the first argument, it should be backup-url")
 	}
 
 	outputFile := c.String("output-file")
@@ -125,7 +125,7 @@ func restoreToFile(c *cli.Context) error {
 	}
 	outputFilePath, err := filepath.Abs(outputFile)
 	if err != nil {
-		return errors.Wrap(err, "Error confirming output file path")
+		return errors.Wrap(err, "error confirming output file path")
 	}
 	logrus.Infof("Output file path=%s", outputFilePath)
 

--- a/app/cmd/snapshot.go
+++ b/app/cmd/snapshot.go
@@ -203,7 +203,7 @@ func createSnapshot(c *cli.Context) error {
 func revertSnapshot(c *cli.Context) error {
 	name := c.Args()[0]
 	if name == "" {
-		return fmt.Errorf("Missing parameter for snapshot")
+		return fmt.Errorf("missing parameter for snapshot")
 	}
 
 	controllerClient, err := getControllerClient(c)
@@ -250,7 +250,7 @@ func purgeSnapshot(c *cli.Context) error {
 
 	skip := c.Bool("skip-if-in-progress")
 	if err := task.PurgeSnapshots(skip); err != nil {
-		return fmt.Errorf("Failed to purge snapshots: %v", err)
+		return errors.Wrap(err, "failed to purge snapshots")
 	}
 
 	return nil
@@ -360,7 +360,7 @@ func infoSnapshot(c *cli.Context) error {
 	}
 
 	if output == nil {
-		return fmt.Errorf("Cannot find suitable replica for snapshot info")
+		return fmt.Errorf("cannot find suitable replica for snapshot info")
 	}
 	fmt.Println(string(output))
 	return nil

--- a/app/cmd/sync_agent.go
+++ b/app/cmd/sync_agent.go
@@ -62,7 +62,7 @@ func startSyncAgent(c *cli.Context) error {
 
 	parts := strings.Split(portRange, "-")
 	if len(parts) != 2 {
-		return fmt.Errorf("Invalid format for range: %s", portRange)
+		return fmt.Errorf("invalid format for range: %s", portRange)
 	}
 
 	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
@@ -77,7 +77,7 @@ func startSyncAgent(c *cli.Context) error {
 
 	listen, err := net.Listen("tcp", listenPort)
 	if err != nil {
-		return errors.Wrap(err, "Failed to listen")
+		return errors.Wrap(err, "failed to listen")
 	}
 
 	server := grpc.NewServer()

--- a/app/cmd/volume.go
+++ b/app/cmd/volume.go
@@ -105,7 +105,7 @@ func expand(c *cli.Context) error {
 func startFrontend(c *cli.Context) error {
 	frontendName := c.Args().First()
 	if frontendName == "" {
-		return fmt.Errorf("Missing required parameter frontendName")
+		return fmt.Errorf("missing required parameter frontendName")
 	}
 
 	controllerClient, err := getControllerClient(c)

--- a/integration/core/test_replica.py
+++ b/integration/core/test_replica.py
@@ -141,11 +141,11 @@ def test_remove_disk(grpc_replica_client):  # NOQA
 
     with pytest.raises(grpc.RpcError) as e:
         grpc_replica_client.disk_mark_as_removed(name='volume-head-002.img')
-    assert "Can not mark the active" in str(e.value)
+    assert "cannot mark the active" in str(e.value)
 
     with pytest.raises(grpc.RpcError) as e:
         grpc_replica_client.disk_prepare_remove(name='volume-head-002.img')
-    assert "Can not delete the active" in str(e.value)
+    assert "cannot delete the active" in str(e.value)
 
     grpc_replica_client.disk_mark_as_removed(name='001')
     ops = grpc_replica_client.disk_prepare_remove(name='001').operations

--- a/main.go
+++ b/main.go
@@ -61,11 +61,11 @@ func cleanup() {
 }
 
 func cmdNotFound(c *cli.Context, command string) {
-	panic(fmt.Errorf("Unrecognized command: %s", command))
+	panic(fmt.Errorf("unrecognized command: %s", command))
 }
 
 func onUsageError(c *cli.Context, err error, isSubcommand bool) error {
-	panic(fmt.Errorf("Usage error, please check your command"))
+	panic(fmt.Errorf("usage error, please check your command"))
 }
 
 func longhornCli() {

--- a/pkg/backup/main.go
+++ b/pkg/backup/main.go
@@ -53,7 +53,7 @@ func ResponseOutput(v interface{}) ([]byte, error) {
 }
 
 func RequiredMissingError(name string) error {
-	return fmt.Errorf("Cannot find valid required parameter: %v", name)
+	return fmt.Errorf("cannot find valid required parameter: %v", name)
 }
 
 func DoBackupCreate(backupName, volumeName, snapshotName, destURL, backingImageName, backingImageChecksum string,
@@ -69,7 +69,7 @@ func DoBackupCreate(backupName, volumeName, snapshotName, destURL, backingImageN
 	}
 
 	if !util.ValidVolumeName(volumeName) {
-		return "", nil, fmt.Errorf("Invalid volume name %v for backup", volumeName)
+		return "", nil, fmt.Errorf("invalid volume name %v for backup", volumeName)
 	}
 
 	if labels != nil {

--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -393,7 +393,7 @@ func (c *Controller) SetReplicaMode(address string, mode types.Mode) error {
 		c.RLock()
 		defer c.RUnlock()
 	default:
-		return fmt.Errorf("can not set to mode %s", mode)
+		return fmt.Errorf("cannot set to mode %s", mode)
 	}
 
 	c.setReplicaModeNoLock(address, mode)
@@ -450,7 +450,7 @@ func (c *Controller) StartFrontend(frontend string) error {
 	}
 	if c.frontend != nil {
 		if c.frontend.FrontendName() != frontend && c.frontend.State() != types.StateDown {
-			return fmt.Errorf("Frontend %v is already started, cannot be set as %v",
+			return fmt.Errorf("frontend %v is already started, cannot be set as %v",
 				c.frontend.FrontendName(), frontend)
 		}
 	}
@@ -513,7 +513,7 @@ func (c *Controller) salvageRevisionCounterDisabledReplicas() error {
 	}
 
 	if len(replicaCandidates) == 0 {
-		return fmt.Errorf("can not find any replica for salvage")
+		return fmt.Errorf("cannot find any replica for salvage")
 	}
 	var bestCandidate types.Replica
 	lastTime := time.Unix(0, lastModifyTime)

--- a/pkg/controller/rebuild.go
+++ b/pkg/controller/rebuild.go
@@ -83,7 +83,7 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 
 		}
 		if err := c.backend.SetRevisionCounter(address, counter); err != nil {
-			return fmt.Errorf("failed to set revision counter for %v: %v", address, err)
+			return errors.Wrapf(err, "failed to set revision counter for %v", address)
 		}
 	}
 
@@ -99,15 +99,13 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 
 	fromClient, err := client.NewReplicaClient(fromReplica.Address)
 	if err != nil {
-		return fmt.Errorf("cannot get replica client for %v: %v",
-			fromReplica.Address, err)
+		return errors.Wrapf(err, "cannot get replica client for %v", fromReplica.Address)
 	}
 	defer fromClient.Close()
 
 	toClient, err := client.NewReplicaClient(toReplica.Address)
 	if err != nil {
-		return fmt.Errorf("cannot get replica client for %v: %v",
-			toReplica.Address, err)
+		return errors.Wrapf(err, "cannot get replica client for %v", toReplica.Address)
 	}
 	defer toClient.Close()
 
@@ -135,7 +133,7 @@ func (c *Controller) PrepareRebuildReplica(address string) ([]types.SyncFileInfo
 
 	if !c.revisionCounterDisabled {
 		if err := c.backend.SetRevisionCounter(address, 0); err != nil {
-			return nil, fmt.Errorf("failed to set revision counter for %v: %v", address, err)
+			return nil, errors.Wrapf(err, "failed to set revision counter for %v", address)
 		}
 	}
 

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/longhorn/longhorn-engine/pkg/replica/client"
 	"github.com/longhorn/longhorn-engine/pkg/types"
 )
@@ -26,15 +28,13 @@ func GenerateSnapshotDiskMetaName(diskName string) string {
 func GetReplicaDisksAndHead(address string) (map[string]types.DiskInfo, string, error) {
 	repClient, err := client.NewReplicaClient(address)
 	if err != nil {
-		return nil, "", fmt.Errorf("cannot get replica client for %v: %v",
-			address, err)
+		return nil, "", errors.Wrapf(err, "cannot get replica client for %v", address)
 	}
 	defer repClient.Close()
 
 	rep, err := repClient.GetReplica()
 	if err != nil {
-		return nil, "", fmt.Errorf("cannot get replica for %v: %v",
-			address, err)
+		return nil, "", errors.Wrapf(err, "cannot get replica for %v", address)
 	}
 
 	if len(rep.Chain) == 0 {

--- a/pkg/frontend/rest/frontend.go
+++ b/pkg/frontend/rest/frontend.go
@@ -92,9 +92,9 @@ func (d *Device) Endpoint() string {
 }
 
 func (d *Device) Upgrade(name string, size, sectorSize int64, rw types.ReaderWriterAt) error {
-	return fmt.Errorf("Upgrade is not supported")
+	return fmt.Errorf("upgrade is not supported")
 }
 
 func (d *Device) Expand(size int64) error {
-	return fmt.Errorf("Expand is not supported")
+	return fmt.Errorf("expand is not supported")
 }

--- a/pkg/frontend/rest/server.go
+++ b/pkg/frontend/rest/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
@@ -53,7 +54,7 @@ func (s *Server) ReadAt(rw http.ResponseWriter, req *http.Request) error {
 	_, err := s.d.backend.ReadAt(buf, input.Offset)
 	if err != nil {
 		log.Errorln("read failed: ", err.Error())
-		return fmt.Errorf("read failed: %v", err.Error())
+		return errors.Wrap(err, "read failed")
 	}
 
 	data := EncodeData(buf)

--- a/pkg/frontend/socket/frontend.go
+++ b/pkg/frontend/socket/frontend.go
@@ -159,9 +159,9 @@ func (d DataProcessorWrapper) PingResponse() error {
 }
 
 func (t *Socket) Upgrade(name string, size, sectorSize int64, rw types.ReaderWriterAt) error {
-	return fmt.Errorf("Upgrade is not supported")
+	return fmt.Errorf("upgrade is not supported")
 }
 
 func (t *Socket) Expand(size int64) error {
-	return fmt.Errorf("Expand is not supported")
+	return fmt.Errorf("expand is not supported")
 }

--- a/pkg/qcow/libqcow.go
+++ b/pkg/qcow/libqcow.go
@@ -20,7 +20,7 @@ func toError(e *C.libqcow_error_t) error {
 	buf := [1024]C.char{}
 	defer C.libqcow_error_free(&e)
 	if C.libqcow_error_sprint(e, &buf[0], 1023) < 0 {
-		return fmt.Errorf("Unknown error: %v", e)
+		return fmt.Errorf("unknown error: %v", e)
 	}
 	return errors.New(C.GoString(&buf[0]))
 }
@@ -44,7 +44,7 @@ func Open(path string) (*Qcow, error) {
 }
 
 func (q *Qcow) WriteAt(buf []byte, off int64) (int, error) {
-	return 0, errors.New("Unsupported operation")
+	return 0, errors.New("unsupported operation")
 }
 
 func (q *Qcow) ReadAt(buf []byte, off int64) (int, error) {

--- a/pkg/replica/backup.go
+++ b/pkg/replica/backup.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/longhorn-engine/pkg/backingfile"
@@ -206,12 +207,12 @@ func (rb *BackupStatus) OpenSnapshot(snapID, volumeID string) error {
 	}
 
 	if rb.volumeID != "" {
-		return fmt.Errorf("Volume %s and snapshot %s are already open, close first", rb.volumeID, rb.SnapshotID)
+		return fmt.Errorf("volume %s and snapshot %s are already open, close first", rb.volumeID, rb.SnapshotID)
 	}
 
 	dir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("Cannot get working directory: %v", err)
+		return errors.Wrap(err, "cannot get working directory")
 	}
 	r, err := NewReadOnly(dir, id, rb.backingFile)
 	if err != nil {
@@ -227,7 +228,7 @@ func (rb *BackupStatus) OpenSnapshot(snapID, volumeID string) error {
 
 func (rb *BackupStatus) assertOpen(id, volumeID string) error {
 	if rb.volumeID != volumeID || rb.SnapshotID != id {
-		return fmt.Errorf("Invalid state volume [%s] and snapshot [%s] are open, not volume [%s], snapshot [%s]", rb.volumeID, rb.SnapshotID, volumeID, id)
+		return fmt.Errorf("invalid state volume [%s] and snapshot [%s] are open, not volume [%s], snapshot [%s]", rb.volumeID, rb.SnapshotID, volumeID, id)
 	}
 	return nil
 }
@@ -288,12 +289,12 @@ func (rb *BackupStatus) CompareSnapshot(snapID, compareSnapID, volumeID string) 
 
 	from := rb.findIndex(id)
 	if from < 0 {
-		return nil, fmt.Errorf("Failed to find snapshot %s in chain", id)
+		return nil, fmt.Errorf("failed to find snapshot %s in chain", id)
 	}
 
 	to := rb.findIndex(compareID)
 	if to < 0 {
-		return nil, fmt.Errorf("Failed to find snapshot %s in chain", compareID)
+		return nil, fmt.Errorf("failed to find snapshot %s in chain", compareID)
 	}
 
 	mappings := &backupstore.Mappings{

--- a/pkg/replica/client/client.go
+++ b/pkg/replica/client/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -192,7 +193,7 @@ func (c *ReplicaClient) GetReplica() (*types.ReplicaInfo, error) {
 
 	resp, err := replicaServiceClient.ReplicaGet(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get replica %v: %v", c.replicaServiceURL, err)
+		return nil, errors.Wrapf(err, "failed to get replica %v", c.replicaServiceURL)
 	}
 
 	return GetReplicaInfo(resp.Replica), nil
@@ -207,7 +208,7 @@ func (c *ReplicaClient) OpenReplica() error {
 	defer cancel()
 
 	if _, err := replicaServiceClient.ReplicaOpen(ctx, &empty.Empty{}); err != nil {
-		return fmt.Errorf("failed to open replica %v: %v", c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to open replica %v", c.replicaServiceURL)
 	}
 
 	return nil
@@ -222,7 +223,7 @@ func (c *ReplicaClient) CloseReplica() error {
 	defer cancel()
 
 	if _, err := replicaServiceClient.ReplicaClose(ctx, &empty.Empty{}); err != nil {
-		return fmt.Errorf("failed to close replica %v: %v", c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to close replica %v", c.replicaServiceURL)
 	}
 
 	return nil
@@ -238,7 +239,7 @@ func (c *ReplicaClient) ReloadReplica() (*types.ReplicaInfo, error) {
 
 	resp, err := replicaServiceClient.ReplicaReload(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to reload replica %v: %v", c.replicaServiceURL, err)
+		return nil, errors.Wrapf(err, "failed to reload replica %v", c.replicaServiceURL)
 	}
 
 	return GetReplicaInfo(resp.Replica), nil
@@ -274,7 +275,7 @@ func (c *ReplicaClient) Revert(name, created string) error {
 		Name:    name,
 		Created: created,
 	}); err != nil {
-		return fmt.Errorf("failed to revert replica %v: %v", c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to revert replica %v", c.replicaServiceURL)
 	}
 
 	return nil
@@ -292,7 +293,7 @@ func (c *ReplicaClient) RemoveDisk(disk string, force bool) error {
 		Name:  disk,
 		Force: force,
 	}); err != nil {
-		return fmt.Errorf("failed to remove disk %v for replica %v: %v", disk, c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to remove disk %v for replica %v", disk, c.replicaServiceURL)
 	}
 
 	return nil
@@ -310,7 +311,7 @@ func (c *ReplicaClient) ReplaceDisk(target, source string) error {
 		Target: target,
 		Source: source,
 	}); err != nil {
-		return fmt.Errorf("failed to replace disk %v with %v for replica %v: %v", target, source, c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to replace disk %v with %v for replica %v", target, source, c.replicaServiceURL)
 	}
 
 	return nil
@@ -329,7 +330,7 @@ func (c *ReplicaClient) PrepareRemoveDisk(disk string) ([]*types.PrepareRemoveAc
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare removing disk %v for replica %v: %v", disk, c.replicaServiceURL, err)
+		return nil, errors.Wrapf(err, "failed to prepare removing disk %v for replica %v", disk, c.replicaServiceURL)
 	}
 
 	operations := []*types.PrepareRemoveAction{}
@@ -355,7 +356,7 @@ func (c *ReplicaClient) MarkDiskAsRemoved(disk string) error {
 	if _, err := replicaServiceClient.DiskMarkAsRemoved(ctx, &ptypes.DiskMarkAsRemovedRequest{
 		Name: disk,
 	}); err != nil {
-		return fmt.Errorf("failed to mark disk %v as removed for replica %v: %v", disk, c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to mark disk %v as removed for replica %v", disk, c.replicaServiceURL)
 	}
 
 	return nil
@@ -372,7 +373,7 @@ func (c *ReplicaClient) SetRebuilding(rebuilding bool) error {
 	if _, err := replicaServiceClient.RebuildingSet(ctx, &ptypes.RebuildingSetRequest{
 		Rebuilding: rebuilding,
 	}); err != nil {
-		return fmt.Errorf("failed to set rebuilding to %v for replica %v: %v", rebuilding, c.replicaServiceURL, err)
+		return errors.Wrapf(err, "failed to set rebuilding to %v for replica %v", rebuilding, c.replicaServiceURL)
 	}
 
 	return nil
@@ -389,7 +390,7 @@ func (c *ReplicaClient) RemoveFile(file string) error {
 	if _, err := syncAgentServiceClient.FileRemove(ctx, &ptypes.FileRemoveRequest{
 		FileName: file,
 	}); err != nil {
-		return fmt.Errorf("failed to remove file %v: %v", file, err)
+		return errors.Wrapf(err, "failed to remove file %v", file)
 	}
 
 	return nil
@@ -407,7 +408,7 @@ func (c *ReplicaClient) RenameFile(oldFileName, newFileName string) error {
 		OldFileName: oldFileName,
 		NewFileName: newFileName,
 	}); err != nil {
-		return fmt.Errorf("failed to rename or replace old file %v with new file %v: %v", oldFileName, newFileName, err)
+		return errors.Wrapf(err, "failed to rename or replace old file %v with new file %v", oldFileName, newFileName)
 	}
 
 	return nil
@@ -426,7 +427,7 @@ func (c *ReplicaClient) SendFile(from, host string, port int32) error {
 		Host:         host,
 		Port:         port,
 	}); err != nil {
-		return fmt.Errorf("failed to send file %v to %v:%v: %v", from, host, port, err)
+		return errors.Wrapf(err, "failed to send file %v to %v:%v", from, host, port)
 	}
 
 	return nil
@@ -447,7 +448,7 @@ func (c *ReplicaClient) ExportVolume(snapshotName, host string, port int32, expo
 		Port:                      port,
 		ExportBackingImageIfExist: exportBackingImageIfExist,
 	}); err != nil {
-		return fmt.Errorf("failed to export snapshot %v to %v:%v: %v", snapshotName, host, port, err)
+		return errors.Wrapf(err, "failed to export snapshot %v to %v:%v", snapshotName, host, port)
 	}
 	return nil
 }
@@ -464,7 +465,7 @@ func (c *ReplicaClient) LaunchReceiver(toFilePath string) (string, int32, error)
 		ToFileName: toFilePath,
 	})
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to launch receiver for %v: %v", toFilePath, err)
+		return "", 0, errors.Wrapf(err, "failed to launch receiver for %v", toFilePath)
 	}
 
 	return c.host, reply.Port, nil
@@ -483,7 +484,7 @@ func (c *ReplicaClient) SyncFiles(fromAddress string, list []types.SyncFileInfo)
 		ToHost:           c.host,
 		SyncFileInfoList: syncFileInfoListToSyncAgentGRPCFormat(list),
 	}); err != nil {
-		return fmt.Errorf("failed to sync files %+v from %v: %v", list, fromAddress, err)
+		return errors.Wrapf(err, "failed to sync files %+v from %v", list, fromAddress)
 	}
 
 	return nil
@@ -508,7 +509,7 @@ func (c *ReplicaClient) CreateBackup(backupName, snapshot, dest, volume, backing
 		BackupName:           backupName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create backup to %v for volume %v: %v", dest, volume, err)
+		return nil, errors.Wrapf(err, "failed to create backup to %v for volume %v", dest, volume)
 	}
 
 	return resp, nil
@@ -544,7 +545,7 @@ func (c *ReplicaClient) RmBackup(backup string) error {
 	if _, err := syncAgentServiceClient.BackupRemove(ctx, &ptypes.BackupRemoveRequest{
 		Backup: backup,
 	}); err != nil {
-		return fmt.Errorf("failed to remove backup %v: %v", backup, err)
+		return errors.Wrapf(err, "failed to remove backup %v", backup)
 	}
 
 	return nil
@@ -563,7 +564,7 @@ func (c *ReplicaClient) RestoreBackup(backup, snapshotDiskName string, credentia
 		SnapshotDiskName: snapshotDiskName,
 		Credential:       credential,
 	}); err != nil {
-		return fmt.Errorf("failed to restore backup data %v to snapshot file %v: %v", backup, snapshotDiskName, err)
+		return errors.Wrapf(err, "failed to restore backup data %v to snapshot file %v", backup, snapshotDiskName)
 	}
 
 	return nil
@@ -578,7 +579,7 @@ func (c *ReplicaClient) Reset() error {
 	defer cancel()
 
 	if _, err := syncAgentServiceClient.Reset(ctx, &empty.Empty{}); err != nil {
-		return fmt.Errorf("failed to cleanup restore info in Sync Agent Server: %v", err)
+		return errors.Wrap(err, "failed to cleanup restore info in Sync Agent Server")
 	}
 
 	return nil
@@ -594,7 +595,7 @@ func (c *ReplicaClient) RestoreStatus() (*ptypes.RestoreStatusResponse, error) {
 
 	resp, err := syncAgentServiceClient.RestoreStatus(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get restore status: %v", err)
+		return nil, errors.Wrap(err, "failed to get restore status")
 	}
 
 	return resp, nil
@@ -609,7 +610,7 @@ func (c *ReplicaClient) SnapshotPurge() error {
 	defer cancel()
 
 	if _, err := syncAgentServiceClient.SnapshotPurge(ctx, &empty.Empty{}); err != nil {
-		return fmt.Errorf("failed to start snapshot purge: %v", err)
+		return errors.Wrap(err, "failed to start snapshot purge")
 	}
 
 	return nil
@@ -625,7 +626,7 @@ func (c *ReplicaClient) SnapshotPurgeStatus() (*ptypes.SnapshotPurgeStatusRespon
 
 	status, err := syncAgentServiceClient.SnapshotPurgeStatus(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get snapshot purge status: %v", err)
+		return nil, errors.Wrap(err, "failed to get snapshot purge status")
 	}
 
 	return status, nil
@@ -641,7 +642,7 @@ func (c *ReplicaClient) ReplicaRebuildStatus() (*ptypes.ReplicaRebuildStatusResp
 
 	status, err := syncAgentServiceClient.ReplicaRebuildStatus(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get replica rebuild status: %v", err)
+		return nil, errors.Wrap(err, "failed to get replica rebuild status")
 	}
 
 	return status, nil
@@ -661,7 +662,7 @@ func (c *ReplicaClient) CloneSnapshot(fromAddress, snapshotFileName string, expo
 		SnapshotFileName:          snapshotFileName,
 		ExportBackingImageIfExist: exportBackingImageIfExist,
 	}); err != nil {
-		return fmt.Errorf("failed to clone snapshot %v from replica %v to host %v: %v", snapshotFileName, fromAddress, c.host, err)
+		return errors.Wrapf(err, "failed to clone snapshot %v from replica %v to host %v", snapshotFileName, fromAddress, c.host)
 	}
 
 	return nil
@@ -677,7 +678,7 @@ func (c *ReplicaClient) SnapshotCloneStatus() (*ptypes.SnapshotCloneStatusRespon
 
 	status, err := syncAgentServiceClient.SnapshotCloneStatus(ctx, &empty.Empty{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get snapshot clone status: %v", err)
+		return nil, errors.Wrap(err, "failed to get snapshot clone status")
 	}
 	return status, nil
 }

--- a/pkg/replica/diff_disk.go
+++ b/pkg/replica/diff_disk.go
@@ -114,7 +114,7 @@ func (d *diffDisk) readModifyWrite(buf []byte, offset int64) (int, error) {
 
 func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 	if int64(len(buf))%d.sectorSize != 0 || offset%d.sectorSize != 0 {
-		return 0, fmt.Errorf("Write len(%d), offset %d not a multiple of %d", len(buf), offset, d.sectorSize)
+		return 0, fmt.Errorf("write len(%d), offset %d not a multiple of %d", len(buf), offset, d.sectorSize)
 	}
 
 	target := byte(len(d.files) - 1)
@@ -172,7 +172,7 @@ func (d *diffDisk) ReadAt(buf []byte, offset int64) (int, error) {
 
 func (d *diffDisk) fullReadAt(buf []byte, offset int64) (int, error) {
 	if int64(len(buf))%d.sectorSize != 0 || offset%d.sectorSize != 0 {
-		return 0, fmt.Errorf("Read not a multiple of %d", d.sectorSize)
+		return 0, fmt.Errorf("read not a multiple of %d", d.sectorSize)
 	}
 
 	if len(buf) == 0 {

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -163,7 +163,7 @@ func NewReadOnly(dir, head string, backingFile *backingfile.BackingFile) (*Repli
 
 func construct(readonly bool, size, sectorSize int64, dir, head string, backingFile *backingfile.BackingFile, disableRevCounter bool) (*Replica, error) {
 	if size%sectorSize != 0 {
-		return nil, fmt.Errorf("Size %d not a multiple of sector size %d", size, sectorSize)
+		return nil, fmt.Errorf("size %d not a multiple of sector size %d", size, sectorSize)
 	}
 
 	if err := os.Mkdir(dir, 0700); err != nil && !os.IsExist(err) {
@@ -364,7 +364,7 @@ func (r *Replica) RemoveDiffDisk(name string, force bool) error {
 	defer r.Unlock()
 
 	if name == r.info.Head {
-		return fmt.Errorf("Can not delete the active differencing disk")
+		return fmt.Errorf("cannot delete the active differencing disk")
 	}
 
 	if err := r.removeDiskNode(name, force); err != nil {
@@ -395,11 +395,11 @@ func (r *Replica) MarkDiskAsRemoved(name string) error {
 	}
 
 	if disk == r.info.Head {
-		return fmt.Errorf("Can not mark the active differencing disk as removed")
+		return fmt.Errorf("cannot mark the active differencing disk as removed")
 	}
 
 	if err := r.markDiskAsRemoved(disk); err != nil {
-		return fmt.Errorf("Failed to mark disk %v as removed: %v", disk, err)
+		return errors.Wrapf(err, "failed to mark disk %v as removed", disk)
 	}
 
 	return nil
@@ -407,18 +407,18 @@ func (r *Replica) MarkDiskAsRemoved(name string) error {
 
 func (r *Replica) hardlinkDisk(target, source string) error {
 	if _, err := os.Stat(r.diskPath(source)); err != nil {
-		return fmt.Errorf("Cannot find source of replacing: %v", source)
+		return fmt.Errorf("cannot find source of replacing: %v", source)
 	}
 
 	if _, err := os.Stat(r.diskPath(target)); err == nil {
 		logrus.Infof("Old file %s exists, deleting", target)
 		if err := os.Remove(r.diskPath(target)); err != nil {
-			return fmt.Errorf("Failed to remove %s: %v", target, err)
+			return errors.Wrapf(err, "failed to remove %s", target)
 		}
 	}
 
 	if err := os.Link(r.diskPath(source), r.diskPath(target)); err != nil {
-		return fmt.Errorf("Failed to link %s to %s", source, target)
+		return fmt.Errorf("failed to link %s to %s", source, target)
 	}
 	return nil
 }
@@ -428,7 +428,7 @@ func (r *Replica) ReplaceDisk(target, source string) error {
 	defer r.Unlock()
 
 	if target == r.info.Head {
-		return fmt.Errorf("Can not replace the active differencing disk")
+		return fmt.Errorf("cannot replace the active differencing disk")
 	}
 
 	if err := r.hardlinkDisk(target, source); err != nil {
@@ -477,7 +477,7 @@ func (r *Replica) removeDiskNode(name string, force bool) error {
 	// If snapshot has more than one child, we cannot really delete it
 	if len(children) > 1 {
 		if !force {
-			return fmt.Errorf("Cannot remove snapshot %v with %v children",
+			return fmt.Errorf("cannot remove snapshot %v with %v children",
 				name, len(children))
 		}
 		logrus.Warnf("force delete disk %v with multiple children. Randomly choose a child to inherit", name)
@@ -529,11 +529,11 @@ func (r *Replica) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) 
 	}
 
 	if disk == r.info.Head {
-		return nil, fmt.Errorf("Can not delete the active differencing disk")
+		return nil, fmt.Errorf("cannot delete the active differencing disk")
 	}
 
 	if !data.Removed {
-		return nil, fmt.Errorf("Disk %v hasn't been marked as removed", disk)
+		return nil, fmt.Errorf("disk %v hasn't been marked as removed", disk)
 	}
 
 	actions, err := r.processPrepareRemoveDisks(disk)
@@ -547,7 +547,7 @@ func (r *Replica) processPrepareRemoveDisks(disk string) ([]PrepareRemoveAction,
 	actions := []PrepareRemoveAction{}
 
 	if _, exists := r.diskData[disk]; !exists {
-		return nil, fmt.Errorf("Wrong disk %v doesn't exist", disk)
+		return nil, fmt.Errorf("wrong disk %v doesn't exist", disk)
 	}
 
 	children := r.diskChildrenMap[disk]
@@ -609,7 +609,7 @@ func (r *Replica) DisplayChain() ([]string, error) {
 	for cur != "" {
 		disk, ok := r.diskData[cur]
 		if !ok {
-			return nil, fmt.Errorf("Failed to find metadata for %s", cur)
+			return nil, fmt.Errorf("failed to find metadata for %s", cur)
 		}
 		if !disk.Removed {
 			result = append(result, cur)
@@ -630,7 +630,7 @@ func (r *Replica) Chain() ([]string, error) {
 	for cur != "" {
 		result = append(result, cur)
 		if _, ok := r.diskData[cur]; !ok {
-			return nil, fmt.Errorf("Failed to find metadata for %s", cur)
+			return nil, fmt.Errorf("failed to find metadata for %s", cur)
 		}
 		cur = r.diskData[cur].Parent
 	}
@@ -708,7 +708,7 @@ func (r *Replica) nextFile(parsePattern *regexp.Regexp, pattern, parent string) 
 
 	matches := parsePattern.FindStringSubmatch(parent)
 	if matches == nil {
-		return "", fmt.Errorf("Invalid name %s does not match pattern: %v", parent, parsePattern)
+		return "", fmt.Errorf("invalid name %s does not match pattern: %v", parent, parsePattern)
 	}
 
 	index, _ := strconv.Atoi(matches[1])
@@ -792,13 +792,13 @@ func (r *Replica) linkDisk(oldname, newname string) error {
 func (r *Replica) markDiskAsRemoved(name string) error {
 	disk, ok := r.diskData[name]
 	if !ok {
-		return fmt.Errorf("Cannot find disk %v", name)
+		return fmt.Errorf("cannot find disk %v", name)
 	}
 	if stat, err := os.Stat(r.diskPath(name)); err != nil || stat.IsDir() {
-		return fmt.Errorf("Cannot find disk file %v", name)
+		return fmt.Errorf("cannot find disk file %v", name)
 	}
 	if stat, err := os.Stat(r.diskPath(name + metadataSuffix)); err != nil || stat.IsDir() {
-		return fmt.Errorf("Cannot find disk metafile %v", name+metadataSuffix)
+		return fmt.Errorf("cannot find disk metafile %v", name+metadataSuffix)
 	}
 	disk.Removed = true
 	r.diskData[name] = disk
@@ -859,11 +859,11 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	log := logrus.WithFields(logrus.Fields{"disk": name})
 	log.Info("Starting to create disk")
 	if r.readOnly {
-		return fmt.Errorf("Can not create disk on read-only replica")
+		return fmt.Errorf("cannot create disk on read-only replica")
 	}
 
 	if len(r.activeDiskData)+1 > maximumChainLength {
-		return fmt.Errorf("Too many active disks: %v", len(r.activeDiskData)+1)
+		return fmt.Errorf("too many active disks: %v", len(r.activeDiskData)+1)
 	}
 
 	oldHead := r.info.Head
@@ -993,7 +993,7 @@ func (r *Replica) openLiveChain() error {
 	}
 
 	if len(chain) > maximumChainLength {
-		return fmt.Errorf("Live chain is too long: %v", len(chain))
+		return fmt.Errorf("live chain is too long: %v", len(chain))
 	}
 
 	for i := len(chain) - 1; i >= 0; i-- {
@@ -1113,7 +1113,7 @@ func (r *Replica) Expand(size int64) (err error) {
 	defer r.Unlock()
 
 	if r.info.Size > size {
-		return fmt.Errorf("Cannot expand replica to a smaller size %v", size)
+		return fmt.Errorf("cannot expand replica to a smaller size %v", size)
 	} else if r.info.Size == size {
 		logrus.Infof("Replica had been expanded to size %v", size)
 		return nil
@@ -1132,7 +1132,7 @@ func (r *Replica) Expand(size int64) (err error) {
 
 func (r *Replica) WriteAt(buf []byte, offset int64) (int, error) {
 	if r.readOnly {
-		return 0, fmt.Errorf("Can not write on read-only replica")
+		return 0, fmt.Errorf("cannot write on read-only replica")
 	}
 
 	r.RLock()

--- a/pkg/replica/revision_counter.go
+++ b/pkg/replica/revision_counter.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/longhorn/sparse-tools/sparse"
@@ -26,11 +27,11 @@ func (r *Replica) readRevisionCounter() (int64, error) {
 	buf := make([]byte, revisionBlockSize)
 	_, err := r.revisionFile.ReadAt(buf, 0)
 	if err != nil && err != io.EOF {
-		return 0, fmt.Errorf("failed to read from revision counter file: %v", err)
+		return 0, errors.Wrap(err, "failed to read from revision counter file")
 	}
 	counter, err := strconv.ParseInt(strings.Trim(string(buf), "\x00"), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse revision counter file: %v", err)
+		return 0, errors.Wrap(err, "failed to parse revision counter file")
 	}
 	return counter, nil
 }
@@ -44,7 +45,7 @@ func (r *Replica) writeRevisionCounter(counter int64) error {
 	copy(buf, []byte(strconv.FormatInt(counter, 10)))
 	_, err := r.revisionFile.WriteAt(buf, 0)
 	if err != nil {
-		return fmt.Errorf("failed to write to revision counter file: %v", err)
+		return errors.Wrap(err, "failed to write to revision counter file")
 	}
 	return nil
 }

--- a/pkg/replica/rpc/server.go
+++ b/pkg/replica/rpc/server.go
@@ -139,10 +139,10 @@ func (rs *ReplicaServer) ReplicaReload(ctx context.Context, req *empty.Empty) (*
 
 func (rs *ReplicaServer) ReplicaRevert(ctx context.Context, req *ptypes.ReplicaRevertRequest) (*ptypes.ReplicaRevertResponse, error) {
 	if req.Name == "" {
-		return nil, fmt.Errorf("Cannot accept empty snapshot name")
+		return nil, fmt.Errorf("cannot accept empty snapshot name")
 	}
 	if req.Created == "" {
-		return nil, fmt.Errorf("Need to specific created time")
+		return nil, fmt.Errorf("need to specific created time")
 	}
 
 	if err := rs.s.Revert(req.Name, req.Created); err != nil {
@@ -154,10 +154,10 @@ func (rs *ReplicaServer) ReplicaRevert(ctx context.Context, req *ptypes.ReplicaR
 
 func (rs *ReplicaServer) ReplicaSnapshot(ctx context.Context, req *ptypes.ReplicaSnapshotRequest) (*ptypes.ReplicaSnapshotResponse, error) {
 	if req.Name == "" {
-		return nil, fmt.Errorf("Cannot accept empty snapshot name")
+		return nil, fmt.Errorf("cannot accept empty snapshot name")
 	}
 	if req.Created == "" {
-		return nil, fmt.Errorf("Need to specific created time")
+		return nil, fmt.Errorf("need to specific created time")
 	}
 
 	if err := rs.s.Snapshot(req.Name, req.UserCreated, req.Created, req.Labels); err != nil {

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -71,7 +71,7 @@ func (s *Server) Open() error {
 	defer s.Unlock()
 
 	if s.r != nil {
-		return fmt.Errorf("Replica is already open")
+		return fmt.Errorf("replica is already open")
 	}
 
 	_, info := s.Status()
@@ -138,7 +138,7 @@ func (s *Server) SetRebuilding(rebuilding bool) error {
 	// Must be Open/Dirty to set true or must be Rebuilding to set false
 	if (rebuilding && state != Open && state != Dirty) ||
 		(!rebuilding && state != Rebuilding) {
-		return fmt.Errorf("Can not set rebuilding=%v from state %s", rebuilding, state)
+		return fmt.Errorf("cannot set rebuilding=%v from state %s", rebuilding, state)
 	}
 
 	return s.r.SetRebuilding(rebuilding)
@@ -280,7 +280,7 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	defer s.RUnlock()
 
 	if s.r == nil {
-		return 0, fmt.Errorf("Volume no longer exist")
+		return 0, fmt.Errorf("volume no longer exist")
 	}
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
@@ -291,7 +291,7 @@ func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	defer s.RUnlock()
 
 	if s.r == nil {
-		return 0, fmt.Errorf("Volume no longer exist")
+		return 0, fmt.Errorf("volume no longer exist")
 	}
 	i, err := s.r.ReadAt(buf, offset)
 	return i, err

--- a/pkg/sync/backup.go
+++ b/pkg/sync/backup.go
@@ -44,7 +44,7 @@ func (t *Task) CreateBackup(backupName, snapshot, dest, backingImageName, backin
 	var replica *types.ControllerReplicaInfo
 
 	if snapshot == VolumeHeadName {
-		return nil, fmt.Errorf("can not backup the head disk in the chain")
+		return nil, fmt.Errorf("cannot backup the head disk in the chain")
 	}
 
 	volume, err := t.client.VolumeGet()
@@ -175,7 +175,7 @@ func (t *Task) RestoreBackup(backup string, credential map[string]string) error 
 		if isRebuilding, err := t.isRebuilding(r); err != nil {
 			taskErr.Append(NewReplicaError(r.Address, err))
 		} else if isRebuilding {
-			taskErr.Append(NewReplicaError(r.Address, fmt.Errorf("can not do restore for normal rebuilding replica")))
+			taskErr.Append(NewReplicaError(r.Address, fmt.Errorf("cannot do restore for normal rebuilding replica")))
 		}
 	}
 	if taskErr.HasError() {
@@ -284,7 +284,7 @@ func (t *Task) RestoreBackup(backup string, credential map[string]string) error 
 
 func (t *Task) restoreBackup(replicaInController *types.ControllerReplicaInfo, backup string, snapshotFile string, credential map[string]string) error {
 	if replicaInController.Mode == types.ERR {
-		return fmt.Errorf("can not restore backup from replica in mode ERR")
+		return fmt.Errorf("cannot restore backup from replica in mode ERR")
 	}
 
 	repClient, err := replicaClient.NewReplicaClient(replicaInController.Address)
@@ -313,7 +313,7 @@ func (t *Task) Reset() error {
 			return err
 		} else if ok {
 			logrus.Errorf("Replicas are rebuilding. Can't reset: %v", err)
-			return fmt.Errorf("can not reset Restore info as replica(%s) is rebuilding", r.Address)
+			return fmt.Errorf("cannot reset Restore info as replica(%s) is rebuilding", r.Address)
 		}
 	}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -798,7 +798,7 @@ func CloneSnapshot(engineControllerClient, fromControllerClient *client.Controll
 		}
 	}
 	if sourceReplica == nil {
-		return fmt.Errorf("cannot find a RW replica in the source volume for clonning")
+		return fmt.Errorf("cannot find a RW replica in the source volume for cloning")
 	}
 
 	replicas, err = engineControllerClient.ReplicaList()


### PR DESCRIPTION
Error strings should not be capitalized unless beginning with proper nouns or acronyms.

[Longhorn 4828](https://github.com/longhorn/longhorn/issues/4828)

Signed-off-by: Derek Su <derek.su@suse.com>