### PR TITLE
Replica must be closed when rebuilding failed with `too many snapshots created`

### DIFF
--- a/pkg/controller/replicator.go
+++ b/pkg/controller/replicator.go
@@ -343,6 +343,10 @@ func (r *replicator) RemainSnapshots() (int, error) {
 	if ret == math.MaxInt32 {
 		return 0, fmt.Errorf("cannot get valid result for remain snapshot")
 	}
+	if ret <= 0 {
+		return 0, fmt.Errorf("too many snapshots created")
+	}
+
 	return ret, nil
 }
 


### PR DESCRIPTION
Replica banckend needs to be closed if the number of sanpshots is up to the limitation and replica rebuding is occurred.

longhorn/longhorn#3828
