### PR TITLE
fix(replica): volume metafile deleted or empty

### DIFF
--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -113,7 +113,19 @@ func (s *Server) Status() (State, Info) {
 		info, err := ReadInfo(s.dir)
 		if os.IsNotExist(err) {
 			return Initial, Info{}
-		} else if err != nil {
+		}
+
+		replica := Replica{dir: s.dir}
+		volumeMetaFileValid, vaildErr := replica.checkValidVolumeMetaData()
+		if vaildErr != nil {
+			logrus.Errorf("Failed to check if volume metedata is valid in replica directory %s: %v", s.dir, err)
+			return Error, Info{}
+		}
+		if !volumeMetaFileValid {
+			return Initial, Info{}
+		}
+
+		if err != nil {
 			logrus.Errorf("Failed to read info in replica directory %s: %v", s.dir, err)
 			return Error, Info{}
 		}


### PR DESCRIPTION
Volume will be stuck in attaching and detaching loop when attaching a volume with volume metafile deleted or empty.

Try to rebuild the volume metafile when attaching a volume.

longhorn/longhorn#4846

Regression test result: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2601

Run a new Regression test: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2628/