### PR TITLE
[BACKPORT][v1.3.3] fix(replica): volume metafile deleted or empty

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -181,6 +182,11 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	r.info.Size = size
 	r.info.SectorSize = sectorSize
 	r.volume.sectorSize = util.VolumeSectorSize
+
+	// Try to recover volume metafile if deleted or empty.
+	if err := r.tryRecoverVolumeMetaFile(head); err != nil {
+		return nil, err
+	}
 
 	// Scan all the disks to build the disk map
 	exists, err := r.readMetadata()
@@ -1036,6 +1042,50 @@ func (r *Replica) readMetadata() (bool, error) {
 	}
 
 	return len(r.diskData) > 0, nil
+}
+
+func (r *Replica) tryRecoverVolumeMetaFile(head string) error {
+	valid, err := r.checkValidVolumeMetaData()
+	if err != nil {
+		return err
+	}
+	if valid {
+		return nil
+	}
+
+	if head != "" {
+		r.info.Head = head
+	}
+
+	if r.info.Head == "" {
+		files, err := ioutil.ReadDir(r.dir)
+		if err != nil {
+			return err
+		}
+		for _, file := range files {
+			if strings.Contains(file.Name(), types.VolumeHeadName) {
+				r.info.Head = file.Name()
+				break
+			}
+		}
+	}
+
+	logrus.Warnf("Recovering volume metafile %v, and replica info: %+v", r.diskPath(volumeMetaData), r.info)
+	return r.writeVolumeMetaData(true, r.info.Rebuilding)
+}
+
+func (r *Replica) checkValidVolumeMetaData() (bool, error) {
+	err := r.unmarshalFile(r.diskPath(volumeMetaData), &r.info)
+	if err == nil {
+		return true, nil
+	}
+
+	// recover metadata file that does not exist or is empty
+	if os.IsNotExist(err) || errors.Is(err, io.EOF) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func (r *Replica) readDiskData(file string) error {

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -111,7 +111,19 @@ func (s *Server) Status() (State, Info) {
 		info, err := ReadInfo(s.dir)
 		if os.IsNotExist(err) {
 			return Initial, Info{}
-		} else if err != nil {
+		}
+
+		replica := Replica{dir: s.dir}
+		volumeMetaFileValid, vaildErr := replica.checkValidVolumeMetaData()
+		if vaildErr != nil {
+			logrus.Errorf("Failed to check if volume metedata is valid in replica directory %s: %v", s.dir, err)
+			return Error, Info{}
+		}
+		if !volumeMetaFileValid {
+			return Initial, Info{}
+		}
+
+		if err != nil {
 			logrus.Errorf("Failed to read info in replica directory %s: %v", s.dir, err)
 			return Error, Info{}
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -34,6 +34,8 @@ const (
 
 	EngineFrontendBlockDev = "tgt-blockdev"
 	EngineFrontendISCSI    = "tgt-iscsi"
+
+	VolumeHeadName = "volume-head"
 )
 
 type ReaderWriterAt interface {


### PR DESCRIPTION
Volume will be stuck in attaching and detaching loop when attaching a volume with volume metafile deleted or empty.

Try to rebuild the volume metafile when attaching a volume.

longhorn/longhorn#4846
https://github.com/longhorn/longhorn/issues/4847