### PR TITLE
Set default engine-replica-timeout vaule for engine controller start command

### DIFF
--- a/app/cmd/controller.go
+++ b/app/cmd/controller.go
@@ -64,6 +64,7 @@ func ControllerCmd() cli.Command {
 			cli.Int64Flag{
 				Name:   "engine-replica-timeout",
 				Hidden: false,
+				Value:  int64(controller.DefaultEngineReplicaTimeout.Seconds()),
 				Usage:  "In seconds. Timeout between engine and replica(s)",
 			},
 			cli.StringFlag{

--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -63,7 +63,7 @@ func (r *Remote) Close() error {
 }
 
 func (r *Remote) open() error {
-	logrus.Infof("Opening: %s", r.name)
+	logrus.Infof("Opening remote: %s", r.name)
 	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure())
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)

--- a/pkg/controller/init_frontend.go
+++ b/pkg/controller/init_frontend.go
@@ -16,7 +16,7 @@ const (
 	defaultScsiTimeout       = 60 * time.Second // SCSI device timeout
 	defaultIscsiAbortTimeout = 15 * time.Second
 
-	defaultEngineReplicaTimeout = 8 * time.Second
+	DefaultEngineReplicaTimeout = 8 * time.Second
 	minEngineReplicaTimeout     = 8 * time.Second
 	maxEngineReplicaTimeout     = 30 * time.Second
 )
@@ -39,8 +39,8 @@ func NewFrontend(frontendType string, iscsiTargetRequestTimeout time.Duration) (
 func DetermineEngineReplicaTimeout(timeout time.Duration) time.Duration {
 	if timeout < minEngineReplicaTimeout ||
 		timeout > maxEngineReplicaTimeout {
-		logrus.Warnf("Using default engine-replica timeout %v instead since the given value %v is not allowable", defaultEngineReplicaTimeout, timeout)
-		return defaultEngineReplicaTimeout
+		logrus.Warnf("Using default engine-replica timeout %v instead since the given value %v is not allowable", DefaultEngineReplicaTimeout, timeout)
+		return DefaultEngineReplicaTimeout
 	}
 	return timeout
 }

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -49,7 +49,7 @@ func (s *Server) Create(size int64) error {
 
 	sectorSize := s.getSectorSize()
 
-	logrus.Infof("Creating volume %s, size %d/%d", s.dir, size, sectorSize)
+	logrus.Infof("Creating replica %s, size %d/%d", s.dir, size, sectorSize)
 	r, err := New(size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (s *Server) Open() error {
 	_, info := s.Status()
 	sectorSize := s.getSectorSize()
 
-	logrus.Infof("Opening volume %s, size %d/%d", s.dir, info.Size, sectorSize)
+	logrus.Infof("Opening replica: dir %s, size %d, sector size %d", s.dir, info.Size, sectorSize)
 	r, err := New(info.Size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (s *Server) Reload() error {
 		return nil
 	}
 
-	logrus.Info("Reloading volume")
+	logrus.Info("Reloading replica")
 	newReplica, err := s.r.Reload()
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func (s *Server) Revert(name, created string) error {
 		return nil
 	}
 
-	logrus.Infof("Reverting to snapshot [%s] on volume at %s", name, created)
+	logrus.Infof("Reverting to snapshot [%s] on replica at %s", name, created)
 	r, err := s.r.Revert(name, created)
 	if err != nil {
 		return err
@@ -264,7 +264,7 @@ func (s *Server) Delete() error {
 		return nil
 	}
 
-	logrus.Infof("Deleting volume")
+	logrus.Infof("Deleting replica")
 	if err := s.r.Close(); err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func (s *Server) Close() error {
 		return nil
 	}
 
-	logrus.Infof("Closing volume")
+	logrus.Infof("Closing replica")
 	if err := s.r.Close(); err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	defer s.RUnlock()
 
 	if s.r == nil {
-		return 0, fmt.Errorf("volume no longer exist")
+		return 0, fmt.Errorf("replica no longer exist")
 	}
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
@@ -307,7 +307,7 @@ func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	defer s.RUnlock()
 
 	if s.r == nil {
-		return 0, fmt.Errorf("volume no longer exist")
+		return 0, fmt.Errorf("replica no longer exist")
 	}
 	i, err := s.r.ReadAt(buf, offset)
 	return i, err
@@ -318,7 +318,7 @@ func (s *Server) UnmapAt(length uint32, off int64) (int, error) {
 	defer s.RUnlock()
 
 	if s.r == nil {
-		return 0, fmt.Errorf("Volume no longer exist")
+		return 0, fmt.Errorf("replica no longer exist")
 	}
 	return s.r.UnmapAt(length, off)
 }


### PR DESCRIPTION
Longhorn/longhorn#5031

Signed-off-by: Derek Su <derek.su@suse.com>