### PR TITLE
meta: update CLIAPIVersion to 8

### DIFF
--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -2,7 +2,7 @@ package meta
 
 const (
 	// CLIAPIVersion used to communicate with user e.g. longhorn-manager
-	CLIAPIVersion    = 7
+	CLIAPIVersion    = 8
 	CLIAPIMinVersion = 3
 
 	// ControllerAPIVersion used to communicate with instance-manager


### PR DESCRIPTION
Update CLIAPIVersion to 8 because of the newly introduced compression enhancement.

Longhorn/longhorn#5376