### PR TITLE
Separate service unavailable and replica error

### DIFF
--- a/app/cmd/controller.go
+++ b/app/cmd/controller.go
@@ -178,7 +178,7 @@ func startController(c *cli.Context) error {
 			// Most of the time, 1 is the exit code when there's an error.
 			// The exit code will be ENODATA (61) if there is no backend.
 			// The engine controller will then catch the ENODATA.
-			if strings.Contains(err.Error(), controller.ControllerErrorNoBackend) {
+			if strings.Contains(err.Error(), controller.ControllerErrorNoBackendReplicaError) {
 				exitCode = int(syscall.ENODATA)
 			}
 			logrus.Error(err.Error())

--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	iutil "github.com/longhorn/go-iscsi-helper/util"
 
@@ -694,6 +696,15 @@ func determineCorrectVolumeSize(volumeSize, volumeCurrentSize int64, backendSize
 	return volumeCurrentSize
 }
 
+func isBackendServiceUnavailable(errorCodes map[string]codes.Code) bool {
+	for _, code := range errorCodes {
+		if code == codes.Unavailable {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Controller) Start(volumeSize, volumeCurrentSize int64, addresses ...string) error {
 	c.Lock()
 	defer c.Unlock()
@@ -714,28 +725,41 @@ func (c *Controller) Start(volumeSize, volumeCurrentSize int64, addresses ...str
 
 	availableBackends := map[string]types.Backend{}
 	backendSizes := map[int64]struct{}{}
+	errorCodes := map[string]codes.Code{}
 	first := true
 	for _, address := range addresses {
 		newBackend, err := c.factory.Create(c.Name, address, c.DataServerProtocol, c.engineReplicaTimeout)
 		if err != nil {
+			if strings.Contains(err.Error(), "rpc error: code = Unavailable") {
+				errorCodes[address] = codes.Unavailable
+			}
 			logrus.WithError(err).Warnf("Failed to create backend with address %v", address)
 			continue
 		}
 
 		newSize, err := newBackend.Size()
 		if err != nil {
+			if strings.Contains(err.Error(), "rpc error: code = Unavailable") {
+				errorCodes[address] = codes.Unavailable
+			}
 			logrus.WithError(err).Warnf("Failed to get the size from the backend address %v", address)
 			continue
 		}
 
 		newSectorSize, err := newBackend.SectorSize()
 		if err != nil {
+			if strings.Contains(err.Error(), "rpc error: code = Unavailable") {
+				errorCodes[address] = codes.Unavailable
+			}
 			logrus.WithError(err).Warnf("Failed to get the sector size from the backend address %v", address)
 			continue
 		}
 
 		state, err := newBackend.GetState()
 		if err != nil {
+			if strings.Contains(err.Error(), "rpc error: code = Unavailable") {
+				errorCodes[address] = codes.Unavailable
+			}
 			logrus.WithError(err).Warnf("Failed to get the state from the backend address %v", address)
 			continue
 		}
@@ -788,7 +812,10 @@ func (c *Controller) Start(volumeSize, volumeCurrentSize int64, addresses ...str
 	}
 
 	if len(availableBackends) == 0 {
-		return fmt.Errorf(ControllerErrorNoBackend+" from the addresses %+v", addresses)
+		if isBackendServiceUnavailable(errorCodes) {
+			return fmt.Errorf(ControllerErrorNoBackendServiceUnavailable+" from the addresses %+v", addresses)
+		}
+		return fmt.Errorf(ControllerErrorNoBackendReplicaError+" from the addresses %+v", addresses)
 	}
 
 	if err := c.checkUnmapMarkSnapChainRemoved(); err != nil {

--- a/pkg/controller/errors.go
+++ b/pkg/controller/errors.go
@@ -1,5 +1,6 @@
 package controller
 
 const (
-	ControllerErrorNoBackend = "cannot create an available backend for the engine"
+	ControllerErrorNoBackendServiceUnavailable = "no available backend due to service unavailable"
+	ControllerErrorNoBackendReplicaError       = "no available backend due to replica error"
 )


### PR DESCRIPTION
When an engine had no available backend, the controller emitted a message stating "...no available backend...". Afterward, the volume controller blindly marked all replicas as failed.

To create a RWX volume, it was first created on node A, and then the sharemanager resource was created with node A as the owner. The sharemanager controller then created a sharemanager pod, which might be located on node B. After the pod was created, the sharemanager resource's owner was transferred to node B, causing the volume to detach from node A and attach to node B.

However, if replicas were deleted because of detachment, the in-progress engine instance's startup would fail due to the "...no available backend..." error. This caused all replicas to be marked as failed (healthyAt is empty and failedAt is set), and they could not be salvaged anymore. As a result, the volume became faulty.

To avoid the blindly marking failed operation, we should separate the recoverable and unrecoverable error. For a recoverable error, for example, the replica instance is deleted, the replica is not really failed, the replica should not be marked as failed directly.

To prevent blindly marking replicas as failed, recoverable and unrecoverable errors can be separated. The manifest corruption can be regarded as a unrecoverable error. For a recoverable error, for instance, if a replica instance is deleted and the controller is disconnected with it, it should not be marked as failed directly since the replica are somehow stopped rather than corrupted. In this case, avoiding marking all replicas failed can help the volume not trapped in a faulty state and reattach to a node.

Longhorn/longhorn#5537