### PR TITLE
[v1.4.x] vendor: update sparse-tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/longhorn/backupstore v0.0.0-20230324161025-944d6c16dd0c
 	github.com/longhorn/go-iscsi-helper v0.0.0-20230215054929-acb305e1031b
-	github.com/longhorn/sparse-tools v0.0.0-20230327064700-b60b990a105b
+	github.com/longhorn/sparse-tools v0.0.0-20230408015858-c849def39d3c
 	github.com/moby/moby v20.10.20+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/longhorn/sparse-tools v0.0.0-20230216042534-6e4173e9def4 h1:cgz+MUSAZ
 github.com/longhorn/sparse-tools v0.0.0-20230216042534-6e4173e9def4/go.mod h1:Uu0wXGD4l7Wfl+xZrCDZKw0zMvYVpwreFRwieZ6083s=
 github.com/longhorn/sparse-tools v0.0.0-20230327064700-b60b990a105b h1:e0M+P+Zpsmps/nUXVDjonPSchpqRXgcwkVcvRRPQSDM=
 github.com/longhorn/sparse-tools v0.0.0-20230327064700-b60b990a105b/go.mod h1:qhbarWiCtB2FFqg7v3KBSRshU7oQgrabmIuN3Sh0cMo=
+github.com/longhorn/sparse-tools v0.0.0-20230408015858-c849def39d3c h1:EAE/cBOWZUL9CDiI4xbOr1IudQUa2e6u/pdScytEcvo=
+github.com/longhorn/sparse-tools v0.0.0-20230408015858-c849def39d3c/go.mod h1:qhbarWiCtB2FFqg7v3KBSRshU7oQgrabmIuN3Sh0cMo=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/vendor/github.com/longhorn/sparse-tools/sparse/rest/server.go
+++ b/vendor/github.com/longhorn/sparse-tools/sparse/rest/server.go
@@ -2,14 +2,57 @@ package rest
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/longhorn/sparse-tools/sparse"
 )
+
+var (
+	defaultIdleTimeout     = 90 * time.Second
+	defaultHTTPIdleTimeout = 60 * time.Second
+)
+
+type IdleTimer struct {
+	sync.Mutex
+	activeConns map[net.Conn]bool
+	timeout     time.Duration
+	timer       *time.Timer
+}
+
+func NewIdleTimer(idleTimeout time.Duration) *IdleTimer {
+	return &IdleTimer{
+		activeConns: make(map[net.Conn]bool),
+		timeout:     idleTimeout,
+		timer:       time.NewTimer(idleTimeout),
+	}
+}
+
+func (it *IdleTimer) ConnState(conn net.Conn, state http.ConnState) {
+	it.Lock()
+	defer it.Unlock()
+
+	switch state {
+	case http.StateNew, http.StateActive, http.StateHijacked:
+		it.activeConns[conn] = true
+		it.timer.Stop()
+	case http.StateIdle, http.StateClosed:
+		delete(it.activeConns, conn)
+		if len(it.activeConns) == 0 {
+			it.timer.Reset(it.timeout)
+		}
+	}
+}
+
+func (t *IdleTimer) Done() <-chan time.Time {
+	return t.timer.C
+}
 
 type DataSyncServer interface {
 	open(writer http.ResponseWriter, request *http.Request)
@@ -36,8 +79,13 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	log.Infof("Creating Ssync service")
 	ctx, cancelFunc := context.WithCancel(ctx)
 	srv := &http.Server{
-		Addr: ":" + port,
+		Addr:        ":" + port,
+		IdleTimeout: defaultHTTPIdleTimeout,
 	}
+
+	// if server has no connection for a period of time, it will shutdown itself to prevent receiver from getting stuck.
+	idleTimer := NewIdleTimer(defaultIdleTimeout)
+	srv.ConnState = idleTimer.ConnState
 
 	fileAlreadyExists := true
 	if _, err := os.Stat(filePath); err != nil && errors.Is(err, os.ErrNotExist) {
@@ -56,8 +104,13 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	srv.Handler = NewRouter(syncServer)
 
 	go func() {
-		<-ctx.Done()
-		srv.Close()
+		select {
+		case <-ctx.Done():
+			srv.Close()
+		case <-idleTimer.Done():
+			log.Errorf("Shutting down the server since it is idle for %v", idleTimer.timeout)
+			srv.Close()
+		}
 	}()
 
 	return srv.ListenAndServe()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -120,7 +120,7 @@ github.com/longhorn/go-iscsi-helper/util
 # github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003
 ## explicit
 github.com/longhorn/nsfilelock
-# github.com/longhorn/sparse-tools v0.0.0-20230327064700-b60b990a105b
+# github.com/longhorn/sparse-tools v0.0.0-20230408015858-c849def39d3c
 ## explicit; go 1.17
 github.com/longhorn/sparse-tools/cli/ssync
 github.com/longhorn/sparse-tools/sparse


### PR DESCRIPTION
Issue: https://github.com/longhorn/longhorn/issues/4305
Depends on: https://github.com/longhorn/sparse-tools/pull/93

Currently, it is not possible to backport vendor update from the master-head to v1.4.x
So we have to create the branch from v1.4.x and create the PR to prevent conflicts.