### PR TITLE
Add replica-instance-name argument to verify-rebuild-replica command

### DIFF
--- a/app/cmd/add_replica.go
+++ b/app/cmd/add_replica.go
@@ -199,6 +199,13 @@ func VerifyRebuildReplicaCmd() cli.Command {
 	return cli.Command{
 		Name:      "verify-rebuild-replica",
 		ShortName: "verify-rebuild",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:     "replica-instance-name",
+				Required: false,
+				Usage:    "Name of the replica instance (for validation purposes)",
+			},
+		},
 		Action: func(c *cli.Context) {
 			if err := verifyRebuildReplica(c); err != nil {
 				logrus.WithError(err).Fatalf("Error running verify rebuild replica command")


### PR DESCRIPTION
longhorn/longhorn#6522

https://github.com/longhorn/longhorn-manager/pull/2108 cause `verify-replica-rebuild` to be called with `--replica-instance-name`, but I missed adding the flag in longhorn/longhorn#5845.