### PR TITLE
build: improve the gPRC generator script

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -141,5 +141,6 @@ RUN cd /go/src/github.com/longhorn && \
 
 VOLUME /tmp
 ENV TMPDIR /tmp
+ENV DAPPER_OUTPUT ./integration/rpc/controller ./integration/rpc/replica ./proto
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-./prebuild
+BUILDER_FLAG=1 ./generate-grpc
 ./build
 ./validate
 ./test

--- a/scripts/ci-without-it
+++ b/scripts/ci-without-it
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-./prebuild
+BUILDER_FLAG=1 ./generate-grpc
 ./build
 ./validate
 ./test

--- a/scripts/generate-grpc
+++ b/scripts/generate-grpc
@@ -2,6 +2,9 @@
 
 set -e
 
+# if BUILDER_FLAG is set, then the script will exit with the error code
+: ${BUILDER_FLAG:=0}
+
 cd $(dirname $0)/..
 
 ./generate_grpc.sh
@@ -12,5 +15,5 @@ if [ $? -eq 0 ]
 then
 	echo $output
 	echo GRPC generated code is not up to date
-	exit 1
+	exit $BUILDER_FLAG
 fi


### PR DESCRIPTION
related to: https://github.com/longhorn/longhorn/issues/6973

Example for the usage.
```
# After we add/modify gRPC call
$ make generate-rpc
... some build logs
integration/rpc/controller/controller_pb2.py | 200 ++++++++++---- integration/rpc/controller/controller_pb2_grpc.py | 17 ++ integration/rpc/replica/re
plica_pb2.py | 114 +++++++- integration/rpc/replica/replica_pb2_grpc.py | 17 ++ proto/ptypes/controller.pb.go | 317 ++++++++++++++++------ proto/ptype
s/replica.pb.go | 307 +++++++++++++++------
Please update GRPC generated code.

$ git status
On branch tmp-gen-rpc
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   integration/rpc/controller/controller_pb2.py
        modified:   integration/rpc/controller/controller_pb2_grpc.py
        modified:   integration/rpc/replica/replica_pb2.py
        modified:   integration/rpc/replica/replica_pb2_grpc.py
        modified:   proto/ptypes/controller.pb.go
        modified:   proto/ptypes/replica.pb.go

no changes added to commit (use "git add" and/or "git commit -a")
```

Also, if we use `make` or `dapper`, the bulder_flag would be set. Then, we still keep the same behavior as before.