### PR TITLE
Renable CI IT for s390x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -234,7 +234,7 @@ steps:
   pull: default
   image: rancher/dapper:v0.5.8
   commands:
-  - dapper ci-without-it
+  - dapper ci
   privileged: true
   volumes:
   - name: socket


### PR DESCRIPTION
Enabling ci with `it` for s390x

Reverting https://github.com/longhorn/longhorn-engine/pull/942 after fixing the issue https://github.com/longhorn/longhorn/issues/6891