### PR TITLE
Revert "refactor: replace deprecated grpc.WithInsecure"

### DIFF
--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/longhorn/longhorn-engine/pkg/dataconn"
 	replicaClient "github.com/longhorn/longhorn-engine/pkg/replica/client"
@@ -46,7 +45,7 @@ type Remote struct {
 
 func (r *Remote) Close() error {
 	logrus.Infof("Closing: %s", r.name)
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)
@@ -66,7 +65,7 @@ func (r *Remote) Close() error {
 
 func (r *Remote) open() error {
 	logrus.Infof("Opening remote: %s", r.name)
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)
@@ -87,7 +86,7 @@ func (r *Remote) open() error {
 func (r *Remote) Snapshot(name string, userCreated bool, created string, labels map[string]string) error {
 	logrus.Infof("Starting to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
 		r.name, name, userCreated, created, labels)
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)
@@ -117,7 +116,7 @@ func (r *Remote) Expand(size int64) (err error) {
 		err = types.WrapError(err, "failed to expand replica %v from remote", r.replicaServiceURL)
 	}()
 
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)
@@ -140,7 +139,7 @@ func (r *Remote) Expand(size int64) (err error) {
 func (r *Remote) SetRevisionCounter(counter int64) error {
 	logrus.Infof("Set revision counter of %s to : %v", r.name, counter)
 
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)
@@ -256,7 +255,7 @@ func (r *Remote) GetUnmapMarkSnapChainRemoved() (bool, error) {
 func (r *Remote) SetUnmapMarkSnapChainRemoved(enabled bool) error {
 	logrus.Infof("Setting UnmapMarkSnapChainRemoved of %s to : %v", r.name, enabled)
 
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "failed connecting to ReplicaService %v", r.replicaServiceURL)
@@ -288,7 +287,7 @@ func (r *Remote) ResetRebuild() error {
 
 	logrus.Warnf("Resetting %v rebuild", r.name)
 
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return errors.Wrapf(err, "failed connecting to ReplicaService %v", r.replicaServiceURL)
@@ -311,7 +310,7 @@ func (r *Remote) ResetRebuild() error {
 }
 
 func (r *Remote) info() (*types.ReplicaInfo, error) {
-	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(r.replicaServiceURL, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect to ReplicaService %v", r.replicaServiceURL)

--- a/pkg/controller/client/controller_client.go
+++ b/pkg/controller/client/controller_client.go
@@ -8,8 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/longhorn/longhorn-engine/pkg/meta"
@@ -46,7 +44,7 @@ const (
 
 func NewControllerClient(address, volumeName, instanceName string) (*ControllerClient, error) {
 	getControllerServiceContext := func(serviceUrl string) (ControllerServiceContext, error) {
-		connection, err := grpc.Dial(serviceUrl, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		connection, err := grpc.Dial(serviceUrl, grpc.WithInsecure(),
 			ptypes.WithIdentityValidationClientInterceptor(volumeName, instanceName))
 		if err != nil {
 			return ControllerServiceContext{}, errors.Wrapf(err, "cannot connect to ControllerService %v", serviceUrl)
@@ -381,7 +379,7 @@ func (c *ControllerClient) VersionDetailGet() (*meta.VersionOutput, error) {
 }
 
 func (c *ControllerClient) Check() error {
-	conn, err := grpc.Dial(c.serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(c.serviceURL, grpc.WithInsecure())
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ControllerService %v", c.serviceURL)
 	}

--- a/pkg/replica/client/client.go
+++ b/pkg/replica/client/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/longhorn/longhorn-engine/pkg/types"
 	"github.com/longhorn/longhorn-engine/pkg/util"
@@ -91,7 +90,7 @@ func NewReplicaClient(address, volumeName, instanceName string) (*ReplicaClient,
 // for the longhorn-manager which executes these command as binaries invocations
 func (c *ReplicaClient) getReplicaServiceClient() (ptypes.ReplicaServiceClient, error) {
 	err := c.replicaServiceContext.once.Do(func() error {
-		cc, err := grpc.Dial(c.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		cc, err := grpc.Dial(c.replicaServiceURL, grpc.WithInsecure(),
 			ptypes.WithIdentityValidationClientInterceptor(c.volumeName, c.instanceName))
 		if err != nil {
 			return err
@@ -112,7 +111,7 @@ func (c *ReplicaClient) getReplicaServiceClient() (ptypes.ReplicaServiceClient, 
 // for the longhorn-manager which executes these command as binaries invocations
 func (c *ReplicaClient) getSyncServiceClient() (ptypes.SyncAgentServiceClient, error) {
 	err := c.syncServiceContext.once.Do(func() error {
-		cc, err := grpc.Dial(c.syncAgentServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		cc, err := grpc.Dial(c.syncAgentServiceURL, grpc.WithInsecure(),
 			ptypes.WithIdentityValidationClientInterceptor(c.volumeName, c.instanceName))
 		if err != nil {
 			return err

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/longhorn/backupstore"
@@ -966,7 +965,7 @@ func (s *SyncAgentServer) postIncrementalRestoreOperations(restoreStatus *replic
 }
 
 func (s *SyncAgentServer) reloadReplica() error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)
@@ -985,7 +984,7 @@ func (s *SyncAgentServer) reloadReplica() error {
 }
 
 func (s *SyncAgentServer) replicaRevert(name, created string) error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)
@@ -1283,7 +1282,7 @@ func getSnapshotsInfo(replicaClient *replicaclient.ReplicaClient) (map[string]ty
 }
 
 func (s *SyncAgentServer) markSnapshotAsRemoved(snapshot string) error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)
@@ -1304,7 +1303,7 @@ func (s *SyncAgentServer) markSnapshotAsRemoved(snapshot string) error {
 }
 
 func (s *SyncAgentServer) processRemoveSnapshot(snapshot string) error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)
@@ -1355,7 +1354,7 @@ func (s *SyncAgentServer) processRemoveSnapshot(snapshot string) error {
 }
 
 func (s *SyncAgentServer) replaceDisk(source, target string) error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)
@@ -1377,7 +1376,7 @@ func (s *SyncAgentServer) replaceDisk(source, target string) error {
 }
 
 func (s *SyncAgentServer) rmDisk(disk string) error {
-	conn, err := grpc.Dial(s.replicaAddress, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.Dial(s.replicaAddress, grpc.WithInsecure(),
 		ptypes.WithIdentityValidationClientInterceptor(s.volumeName, s.instanceName))
 	if err != nil {
 		return errors.Wrapf(err, "cannot connect to ReplicaService %v", s.replicaAddress)


### PR DESCRIPTION
This reverts commit 636a99aad3ba51dd44693a72da5b2d2353734399 for the reason same as https://github.com/longhorn/longhorn-engine/pull/973#issuecomment-1864078004.

https://github.com/longhorn/longhorn/issues/7364