### PR TITLE
feat: replace golint with golangci-lint

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,7 +9,7 @@ ENV PROTOBUF_VER=3.18.0
 # Setup environment
 ENV PATH /go/bin:$PATH
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_ENV TAG REPO
+ENV DAPPER_ENV TAG REPO DRONE_REPO DRONE_PULL_REQUEST DRONE_COMMIT_REF
 ENV DAPPER_OUTPUT bin coverage.out
 ENV DAPPER_RUN_ARGS --privileged --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.venv:exec --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.tox:exec -v /dev:/host/dev -v /proc:/host/proc
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/longhorn-engine
@@ -20,7 +20,7 @@ RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/syste
 
 # Install packages
 RUN if [ ${ARCH} == "amd64" ]; then \
-        zypper -n install autoconf libtool libunwind-devel; \
+    zypper -n install autoconf libtool libunwind-devel; \
     fi
 
 RUN zypper -n install cmake wget curl git less file gcc \
@@ -35,20 +35,20 @@ RUN zypper -n install cmake wget curl git less file gcc \
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN if [ ${ARCH} == "s390x" ]; then \
-        ln -s /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc;\
+    ln -s /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc;\
     fi
 
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.21.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go install golang.org/x/lint/golint@latest
+RUN wget -O - https://storage.googleapis.com/golang/go1.21.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
 # Minio
 ENV MINIO_URL_amd64=https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2021-12-20T22-07-16Z \
     MINIO_URL_arm64=https://dl.min.io/server/minio/release/linux-arm64/archive/minio.RELEASE.2021-12-20T22-07-16Z \
     MINIO_URL_s390x=https://dl.min.io/server/minio/release/linux-s390x/archive/minio.RELEASE.2021-12-20T22-07-16Z \
-	MINIO_URL=MINIO_URL_${ARCH}
+    MINIO_URL=MINIO_URL_${ARCH}
 
 RUN wget ${!MINIO_URL} -O /usr/bin/minio && chmod +x /usr/bin/minio
 
@@ -66,19 +66,19 @@ RUN ldconfig
 ENV GRPC_HEALTH_PROBE_amd64=https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-amd64 \
     GRPC_HEALTH_PROBE_arm64=https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-arm64 \
     GRPC_HEALTH_PROBE_s390x=https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-s390x \
-	GRPC_HEALTH_PROBE=GRPC_HEALTH_PROBE_${ARCH}
+    GRPC_HEALTH_PROBE=GRPC_HEALTH_PROBE_${ARCH}
 
 RUN wget ${!GRPC_HEALTH_PROBE} -O /usr/local/bin/grpc_health_probe && \
     chmod +x /usr/local/bin/grpc_health_probe
 
 # protoc
 ENV PROTOC_amd64=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-x86_64.zip \
-	PROTOC_arm64=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-aarch_64.zip \
-	PROTOC_s390x=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-s390_64.zip \
-	PROTOC=PROTOC_${ARCH}
+    PROTOC_arm64=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-aarch_64.zip \
+    PROTOC_s390x=https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-s390_64.zip \
+    PROTOC=PROTOC_${ARCH}
 
 RUN cd /usr/src && \
-	wget ${!PROTOC} -O protoc_${ARCH}.zip && \
+    wget ${!PROTOC} -O protoc_${ARCH}.zip && \
     unzip protoc_${ARCH}.zip -d /usr/local/
 
 # protoc-gen-go
@@ -94,10 +94,10 @@ RUN cd /go/src/github.com/ && \
 
 # python grpc-tools
 RUN if [ "${ARCH}" == "s390x" ]; then \
-        zypper -n in libopenssl-devel && \
-        GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True pip3 install grpcio==1.25.0 grpcio_tools==1.25.0 protobuf==${PROTOBUF_VER}; \
+    zypper -n in libopenssl-devel && \
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True pip3 install grpcio==1.25.0 grpcio_tools==1.25.0 protobuf==${PROTOBUF_VER}; \
     else \
-        pip3 install grpcio==1.25.0 grpcio_tools==1.25.0 protobuf==${PROTOBUF_VER}; \
+    pip3 install grpcio==1.25.0 grpcio_tools==1.25.0 protobuf==${PROTOBUF_VER}; \
     fi
 
 # buf
@@ -125,9 +125,9 @@ RUN mkdir integration/
 COPY integration/setup.py integration/tox.ini integration/requirements.txt integration/flake8-requirements.txt integration/
 RUN cd integration && \
     if [ "${ARCH}" == "s390x" ]; then \
-        GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True tox --notest;\
+    GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True tox --notest;\
     else \
-        tox --notest; \
+    tox --notest; \
     fi
 
 # Build longhorn-instance-manager for integration testing

--- a/scripts/validate
+++ b/scripts/validate
@@ -10,12 +10,21 @@ echo Packages: ${PACKAGES}
 
 echo Running: go vet
 go vet ${PACKAGES}
-echo Running: golint
-for i in ${PACKAGES}; do
-    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | grep -v 'just return error instead.'| tee /dev/stderr)" ]; then
-        failed=true
-    fi
-done
-test -z "$failed"
+
+if [ ! -z "${DRONE_REPO}" ] && [ ! -z "${DRONE_PULL_REQUEST}" ]; then
+	wget https://github.com/$DRONE_REPO/pull/$DRONE_PULL_REQUEST.patch
+	echo "Running: golangci-lint run --new-from-patch=${DRONE_PULL_REQUEST}.patch"
+	golangci-lint run --new-from-patch="${DRONE_PULL_REQUEST}.patch"
+	rm "${DRONE_PULL_REQUEST}.patch"
+elif [ ! -z "${DRONE_COMMIT_REF}" ]; then
+	echo "Running: golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}"
+	golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}
+else
+	git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^"
+	headSHA=$(git rev-parse --short=12 ${REV})
+	echo "Running: golangci-lint run --new-from-rev=${headSHA}"
+	golangci-lint run --new-from-rev=${headSHA}
+fi
+
 echo Running: go fmt
 test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"


### PR DESCRIPTION
issue: https://github.com/longhorn/longhorn/issues/7366

Using `golangci-lint run --new-from-rev=` or `golangci-lint run --new-from-patch=` because there are too many warning for current code.

Ref: https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues