### PR TITLE
fix: replace copy/paste error in salvage replica picking when revisio…

### DIFF
--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -554,7 +554,7 @@ func (c *Controller) salvageRevisionCounterDisabledReplicas() error {
 			return err
 		}
 
-		repHeadFileSize, err := c.backend.backends[r.Address].backend.GetLastModifyTime()
+		repHeadFileSize, err := c.backend.backends[r.Address].backend.GetHeadFileSize()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
…n counter is disabled.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7714

#### What this PR does / why we need it:

There is a clear error in salvageRevisionCounterDisabledReplicas.

#### Special notes for your reviewer:

Builds and passes unit tests.  No regressions run yet.

#### Additional documentation or context
