### PR TITLE
 ci: run integration-test only if gh event is PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,9 @@ steps:
   volumes:
   - name: socket
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: build-with-skip-tasks
   pull: default
@@ -158,6 +161,9 @@ steps:
   volumes:
   - name: socket
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: build-with-skip-tasks
   pull: default


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

#### What this PR does / why we need it:

Run integration-tests only when the GitHub event is PR. 

#### Special notes for your reviewer:

#### Additional documentation or context
