### PR TITLE
ci: skip integration-test if gh event is not PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,21 @@ steps:
   - name: socket
     path: /var/run/docker.sock
 
+- name: build-with-skip-tasks
+  pull: default
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper ci
+  environment:
+    SKIP_TASKS: integration-test
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
+  when:
+    event:
+      exclude:
+      - pull_request
+
 - name: codecov
   image: robertstettner/drone-codecov
   settings:
@@ -44,19 +59,19 @@ steps:
     FOSSA_API_KEY:
       from_secret: FOSSA_API_KEY
   commands:
-    - zypper -n install curl unzip
-    - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh"
-    - fossa analyze
-    - fossa test
+  - zypper -n install curl unzip
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh"
+  - fossa analyze
+  - fossa test
   when:
     instance:
-      - drone-publish.longhorn.io
+    - drone-publish.longhorn.io
     ref:
       include:
-        - "refs/heads/master"
+      - "refs/heads/master"
     event:
-      - push
-      - tag
+    - push
+    - tag
 
 - name: publish-image
   image: plugins/docker
@@ -107,7 +122,7 @@ steps:
       include:
       - drone-publish.longhorn.io
     status:
-      - failure
+    - failure
 
 volumes:
 - name: socket
@@ -145,6 +160,21 @@ steps:
   volumes:
   - name: socket
     path: /var/run/docker.sock
+
+- name: build-with-skip-tasks
+  pull: default
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper ci
+  environment:
+    SKIP_TASKS: integration-test
+  volumes:
+  - name: socket
+    path: /var/run/docker.sock
+  when:
+    event:
+      exclude:
+      - pull_request
 
 - name: publish-image
   image: plugins/docker
@@ -195,7 +225,7 @@ steps:
       include:
       - drone-publish.longhorn.io
     status:
-      - failure
+    - failure
 
 volumes:
 - name: socket
@@ -228,8 +258,8 @@ steps:
     password:
       from_secret: docker_password
     platforms:
-      - linux/amd64
-      - linux/arm64
+    - linux/amd64
+    - linux/arm64
     target: "longhornio/longhorn-engine:${DRONE_BRANCH}-head"
     template: "longhornio/longhorn-engine:${DRONE_BRANCH}-head-ARCH"
   when:
@@ -246,8 +276,8 @@ steps:
     password:
       from_secret: docker_password
     platforms:
-      - linux/amd64
-      - linux/arm64
+    - linux/amd64
+    - linux/arm64
     target: "longhornio/longhorn-engine:${DRONE_TAG}"
     template: "longhornio/longhorn-engine:${DRONE_TAG}-ARCH"
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,6 +29,9 @@ steps:
   volumes:
   - name: socket
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: build-with-skip-tasks
   pull: default
@@ -160,6 +163,9 @@ steps:
   volumes:
   - name: socket
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: build-with-skip-tasks
   pull: default

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,7 +9,7 @@ ENV PROTOBUF_VER=3.18.0
 # Setup environment
 ENV PATH /go/bin:$PATH
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_ENV TAG REPO
+ENV DAPPER_ENV TAG REPO SKIP_TASKS
 ENV DAPPER_OUTPUT bin coverage.out
 ENV DAPPER_RUN_ARGS --privileged --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.venv:exec --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.tox:exec -v /dev:/host/dev -v /proc:/host/proc
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/longhorn-engine

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,11 +1,21 @@
 #!/bin/bash
+
 set -e
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-./prebuild
-./build
-./validate
-./test
-./integration-test
-./package
+SKIP_TASKS=${SKIP_TASKS:-}
+IFS=' ' read -ra skip_tasks <<<"$SKIP_TASKS"
+
+tasks=("prebuild" "build" "validate" "test" "integration-test" "package")
+
+for task in "${tasks[@]}"; do
+  for skip_task in "${skip_tasks[@]}"; do
+    if [ "$task" = "$skip_task" ]; then
+      continue 2
+    fi
+  done
+
+  ./"$task"
+done
+


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

#### What this PR does / why we need it:

Skip integration-test when doing image build. Run it only when the GitHub event is PR.

#### Special notes for your reviewer:

#### Additional documentation or context
