### PR TITLE
Automatically add Longhorn device to the group id 6 (disk group) by default

### DIFF
--- a/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
+++ b/vendor/github.com/longhorn/go-iscsi-helper/util/util.go
@@ -84,6 +84,9 @@ func DuplicateDevice(dev *lhtypes.BlockDeviceInfo, dest string) error {
 	if err := os.Chmod(dest, 0660); err != nil {
 		return errors.Wrapf(err, "cannot change permission of the device %s", dest)
 	}
+	if err := os.Chown(dest, 0, 6); err != nil {
+		return errors.Wrapf(err, "cannot change onwership of the device %s", dest)
+	}
 	return nil
 }
 


### PR DESCRIPTION
More explanation is at https://github.com/longhorn/longhorn/issues/8088#issuecomment-1982300242

longhorn/longhorn#8088
