### PR TITLE
fix(instance-maanger): add ldflags when building instance manager

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -138,7 +138,7 @@ RUN cd integration && \
 RUN cd /go/src/github.com/longhorn && \
     git clone https://github.com/longhorn/longhorn-instance-manager.git && \
     cd longhorn-instance-manager && \
-    go build -o ./longhorn-instance-manager && \
+    go build -o ./longhorn-instance-manager -tags netgo -ldflags "-linkmode external -extldflags -static" && \
     cp -r integration/rpc/ ${DAPPER_SOURCE}/integration/rpc/ && \
     install longhorn-instance-manager /usr/local/bin
 


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8094

0. We are now checking out latest instance-manager when buiding instance-manager inside longhorn-engine [here](https://github.com/ChanYiLin/longhorn-engine/commit/563531ded3ed38dc6d5bc05fc7f1729645d31fc4)
1. When users manually exec longhorn-instance-manager inside longhorn-engine image, they will encounter
```
longhorn-instance-manager: error while loading shared libraries: libqcow.so.1: cannot open shared object file: No such file or directory
```
2. Fixed it by adding ldflags so  the binary can find the lib
3. Since we validate engine binary path [here](https://github.com/longhorn/longhorn-instance-manager/blob/master/pkg/process/process_manager.go#L192), we have to soft link the binary inside the container to the tmp path, so the manual script can work.