### PR TITLE
dataconn: Fix error log

### DIFF
--- a/pkg/dataconn/wire.go
+++ b/pkg/dataconn/wire.go
@@ -72,7 +72,7 @@ func (w *Wire) Read() (*Message, error) {
 
 	msg.MagicVersion = binary.LittleEndian.Uint16(w.readHeader[offset:])
 	if msg.MagicVersion != MagicVersion {
-		return nil, fmt.Errorf("wrong API version received: 0x%x", &msg.MagicVersion)
+		return nil, fmt.Errorf("wrong API version received: 0x%x", msg.MagicVersion)
 	}
 	offset += int(unsafe.Sizeof(msg.MagicVersion))
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

When the error is triggered, the log should print out the wrong `msg.MagicVersion` rather than its address

#### Special notes for your reviewer:

#### Additional documentation or context
