### PR TITLE
Ublk

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,6 +6,8 @@ RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/syste
     zypper -n addrepo --refresh https://download.opensuse.org/repositories/network:/utilities/SLE_15_SP5/network:utilities.repo && \
     zypper --gpg-auto-import-keys ref
 
+RUN zypper -n install autoconf automake libtool gcc-c++
+
 RUN zypper -n install cmake curl git gcc wget xsltproc docbook-xsl-stylesheets && \
     rm -rf /var/cache/zypp/*
 
@@ -24,6 +26,22 @@ RUN cd /usr/src && \
     git clone https://github.com/rancher/tgt.git && \
     cd tgt && \
     git checkout ${TGT_COMMIT_ID} && \
+    make; \
+    make install
+
+# Build ubdsrv
+ENV UBD_COMMIT_ID 19d3b2133baf1af8ae3a5fe300c962567fb7b0ce
+RUN git clone --depth 1 --branch liburing-2.5 https://github.com/axboe/liburing.git /usr/src/liburing && \
+    cd /usr/src/liburing && \
+    ./configure --cc=gcc --cxx=g++ && \
+    make -j$(nproc) && \
+    make installgit clone https://github.com/Kampadais/ubdsrv.git && \
+    cd ubdsrv && \
+    git checkout ${UBD_COMMIT_ID} && \
+    export LIBURING_CFLAGS="-I/usr/include/liburing" && \
+    export LIBURING_LIBS="-Lusr/lib/pkgconfig -luring"cd /usr/src && \
+    ls;autoreconf -i && \
+    ./configure && \
     make; \
     make install
 

--- a/pkg/backend/dynamic/dynamic.go
+++ b/pkg/backend/dynamic/dynamic.go
@@ -18,12 +18,11 @@ func New(factories map[string]types.BackendFactory) types.BackendFactory {
 	}
 }
 
-func (d *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration) (types.Backend, error) {
+func (d *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration, replicaStreams int) (types.Backend, error) {
 	parts := strings.SplitN(address, "://", 2)
-
 	if len(parts) == 2 {
 		if factory, ok := d.factories[parts[0]]; ok {
-			return factory.Create(volumeName, parts[1], dataServerProtocol, engineToReplicaTimeout)
+			return factory.Create(volumeName, parts[1], dataServerProtocol, engineToReplicaTimeout, replicaStreams)
 		}
 	}
 

--- a/pkg/backend/file/file.go
+++ b/pkg/backend/file/file.go
@@ -124,7 +124,7 @@ func (f *Wrapper) ResetRebuild() error {
 	return nil
 }
 
-func (ff *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration) (types.Backend, error) {
+func (ff *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration, replicaStreams int) (types.Backend, error) {
 	logrus.Infof("Creating file: %s", address)
 	file, err := os.OpenFile(address, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {

--- a/pkg/controller/init_frontend.go
+++ b/pkg/controller/init_frontend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/longhorn/longhorn-engine/pkg/frontend/rest"
 	"github.com/longhorn/longhorn-engine/pkg/frontend/socket"
 	"github.com/longhorn/longhorn-engine/pkg/frontend/tgt"
+	"github.com/longhorn/longhorn-engine/pkg/frontend/ublk"
 	"github.com/longhorn/longhorn-engine/pkg/types"
 	"github.com/sirupsen/logrus"
 )
@@ -21,7 +22,7 @@ const (
 	maxEngineReplicaTimeout     = 30 * time.Second
 )
 
-func NewFrontend(frontendType string, iscsiTargetRequestTimeout time.Duration) (types.Frontend, error) {
+func NewFrontend(frontendType string, iscsiTargetRequestTimeout time.Duration, frontendQueues int) (types.Frontend, error) {
 	switch frontendType {
 	case "rest":
 		return rest.New(), nil
@@ -31,6 +32,8 @@ func NewFrontend(frontendType string, iscsiTargetRequestTimeout time.Duration) (
 		return tgt.New(devtypes.FrontendTGTBlockDev, defaultScsiTimeout, defaultIscsiAbortTimeout, iscsiTargetRequestTimeout), nil
 	case devtypes.FrontendTGTISCSI:
 		return tgt.New(devtypes.FrontendTGTISCSI, defaultScsiTimeout, defaultIscsiAbortTimeout, iscsiTargetRequestTimeout), nil
+	case "ublk":
+		return ublk.New(frontendQueues), nil
 	default:
 		return nil, fmt.Errorf("unsupported frontend type: %v", frontendType)
 	}

--- a/pkg/dataconn/multi_client.go
+++ b/pkg/dataconn/multi_client.go
@@ -1,0 +1,38 @@
+package dataconn
+
+import (
+	"sync"
+)
+
+type MultiClient struct {
+	lock    sync.Mutex
+	clients []*Client
+	next    int
+}
+
+func NewMultiClient(clients []*Client) *MultiClient {
+	mc := &MultiClient{
+		clients: clients,
+	}
+	return mc
+}
+
+func (mc *MultiClient) getNextClient() *Client {
+	mc.lock.Lock()
+	mc.next = (mc.next + 1) % len(mc.clients)
+	index := mc.next
+	mc.lock.Unlock()
+	return mc.clients[index]
+}
+
+func (mc *MultiClient) ReadAt(buf []byte, offset int64) (int, error) {
+	return mc.getNextClient().ReadAt(buf, offset)
+}
+
+func (mc *MultiClient) WriteAt(buf []byte, offset int64) (int, error) {
+	return mc.getNextClient().WriteAt(buf, offset)
+}
+
+func (mc *MultiClient) UnmapAt(length uint32, offset int64) (int, error) {
+	return mc.getNextClient().UnmapAt(length, offset)
+}

--- a/pkg/frontend/ublk/frontend.go
+++ b/pkg/frontend/ublk/frontend.go
@@ -1,0 +1,250 @@
+package ublk
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/longhorn/longhorn-engine/pkg/dataconn"
+	"github.com/longhorn/longhorn-engine/pkg/types"
+)
+
+const (
+	frontendName = "ublk"
+
+	SocketDirectory = "/var/run"
+	DevPath         = "/dev/longhorn/"
+)
+
+func New(frontendQueues int) *Ublk {
+	return &Ublk{Queues: frontendQueues}
+}
+
+type Ublk struct {
+	Volume     string
+	Size       int64
+	UblkID     int
+	Queues     int
+	QueueDepth int
+	BlockSize  int
+	DaemonPId  int
+
+	isUp         bool
+	socketPath   string
+	socketServer *dataconn.Server
+}
+
+func (u *Ublk) FrontendName() string {
+	return frontendName
+}
+
+func (u *Ublk) Init(name string, size, sectorSize int64) error {
+	u.Volume = name
+	u.Size = size
+
+	return nil
+}
+
+func (u *Ublk) StartUblk() error {
+
+	command := "add"
+	args := []string{"-t", "longhorn", "-f", u.socketPath, "-s", strconv.FormatInt(u.Size, 10), "-d", "32", "-q", strconv.Itoa(u.Queues)}
+
+	cmd := exec.Command("ublk", append([]string{command}, args...)...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Error("Error starting ublk:", err)
+		return nil
+	}
+
+	logrus.Info("ublk started successfully")
+
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal(output, &jsonOutput)
+
+	if err != nil {
+		return err
+	}
+
+	u.UblkID = int(jsonOutput["dev_id"].(float64))
+	u.DaemonPId = int(jsonOutput["daemon_pid"].(float64))
+	u.Queues = int(jsonOutput["nr_hw_queues"].(float64))
+	u.QueueDepth = int(jsonOutput["queue_depth"].(float64))
+	u.BlockSize = int(jsonOutput["block_size"].(float64))
+
+	u.isUp = true
+	return nil
+}
+
+func (u *Ublk) Startup(rwu types.ReaderWriterUnmapperAt) error {
+	if err := u.startSocketServer(rwu); err != nil {
+		return err
+	}
+	go func() {
+		err := u.StartUblk()
+		if err != nil {
+			logrus.Errorf("Failed to start ublk: %v", err)
+		}
+	}()
+
+	return nil
+}
+func (u *Ublk) ShutdownUblk() {
+	comm := "ublk"
+	args := []string{"del", strconv.Itoa(u.UblkID)}
+
+	cmd := exec.Command(comm, args...)
+	logrus.Infof("Running command: %v", cmd.Args)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Errorf("Error stopping ublk: %v", err)
+		return
+	}
+	logrus.Infof("ublk stopped successfully: %v", string(output))
+}
+
+func (u *Ublk) Shutdown() error {
+	_, file, no, ok := runtime.Caller(1)
+	if ok {
+		logrus.Infof("\ncalled from %s#%d\n\n", file, no)
+	}
+	if u.Volume != "" {
+		if u.socketServer != nil {
+			logrus.Infof("Shutting down TGT socket server for %v", u.Volume)
+			u.socketServer.Stop()
+			u.socketServer = nil
+		}
+	}
+	u.isUp = false
+
+	go func() {
+		u.ShutdownUblk()
+	}()
+
+	return nil
+}
+
+func (u *Ublk) State() types.State {
+	if u.isUp {
+		return types.StateUp
+	}
+	return types.StateDown
+}
+
+func (u *Ublk) Endpoint() string {
+	if u.isUp {
+		return u.GetSocketPath()
+	}
+	return ""
+}
+
+func (u *Ublk) GetSocketPath() string {
+	if u.Volume == "" {
+		panic("Invalid volume name")
+	}
+	return filepath.Join(SocketDirectory, "longhorn-"+u.Volume+".sock")
+}
+
+func (u *Ublk) startSocketServer(rwu types.ReaderWriterUnmapperAt) error {
+	socketPath := u.GetSocketPath()
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
+		return errors.Wrapf(err, "cannot create directory %v", filepath.Dir(socketPath))
+	}
+
+	if st, err := os.Stat(socketPath); err == nil && !st.IsDir() {
+		if err := os.Remove(socketPath); err != nil {
+			return err
+		}
+	}
+
+	u.socketPath = socketPath
+	go func() {
+		err := u.startSocketServerListen(rwu)
+		if err != nil {
+			logrus.Errorf("Failed to start socket server: %v", err)
+		}
+	}()
+	return nil
+}
+
+func (u *Ublk) startSocketServerListen(rwu types.ReaderWriterUnmapperAt) error {
+	ln, err := net.Listen("unix", u.socketPath)
+	if err != nil {
+		return err
+	}
+	defer func(ln net.Listener) {
+		err := ln.Close()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to close socket listener")
+		}
+	}(ln)
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to accept socket connection")
+			continue
+		}
+		go u.handleServerConnection(conn, rwu)
+	}
+}
+
+func (u *Ublk) handleServerConnection(c net.Conn, rwu types.ReaderWriterUnmapperAt) {
+	defer func(c net.Conn) {
+		err := c.Close()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to close socket server connection")
+		}
+	}(c)
+
+	server := dataconn.NewServer(c, NewDataProcessorWrapper(rwu))
+	logrus.Info("New data socket connection established")
+	if err := server.Handle(); err != nil && err != io.EOF {
+		logrus.WithError(err).Errorf("Failed to handle socket server connection")
+	} else if err == io.EOF {
+		logrus.Warn("Socket server connection closed")
+	}
+}
+
+type DataProcessorWrapper struct {
+	rwu types.ReaderWriterUnmapperAt
+}
+
+func NewDataProcessorWrapper(rwu types.ReaderWriterUnmapperAt) DataProcessorWrapper {
+	return DataProcessorWrapper{
+		rwu: rwu,
+	}
+}
+
+func (d DataProcessorWrapper) ReadAt(p []byte, off int64) (n int, err error) {
+	return d.rwu.ReadAt(p, off)
+}
+
+func (d DataProcessorWrapper) WriteAt(p []byte, off int64) (n int, err error) {
+	return d.rwu.WriteAt(p, off)
+}
+
+func (d DataProcessorWrapper) UnmapAt(length uint32, off int64) (n int, err error) {
+	return d.rwu.UnmapAt(length, off)
+}
+
+func (d DataProcessorWrapper) PingResponse() error {
+	return nil
+}
+
+func (u *Ublk) Upgrade(name string, size, sectorSize int64, rwu types.ReaderWriterUnmapperAt) error {
+	return fmt.Errorf("upgrade is not supported")
+}
+
+func (u *Ublk) Expand(size int64) error {
+	return fmt.Errorf("expand is not supported")
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -105,7 +105,7 @@ type Backend interface {
 }
 
 type BackendFactory interface {
-	Create(volumeName, address string, dataServerProtocol DataServerProtocol, engineReplicaTimeout time.Duration) (Backend, error)
+	Create(volumeName, address string, dataServerProtocol DataServerProtocol, engineReplicaTimeout time.Duration, replicaStreams int) (Backend, error)
 }
 
 type Controller interface {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!-- 
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issues https://github.com/longhorn/longhorn/issues/5159 , https://github.com/longhorn/longhorn/issues/6590

#### What this PR does / why we need it:

This PR uses @derekbit 's  POC [ubdsrv](https://github.com/derekbit/ubdsrv) to integrate ublk with longhorn-engine.  It also implements multiple TCP connections from the controller to each replica. 

Using ublk as a frontend option significantly boosts the IOPS in the frontend part of the engine. In our tests, we measure up to ~500k IOPS at the frontend (before the controller communicates with the replicas).

Using multiple streams between the controller and the replicas also removes part of the communication bottleneck and boosts IOPS from ~50k to ~170k (measured before each replica's R/W operations).

With both features enabled, we measure 110k IOPS on reads (instead of 50k with the default version). Write operations yield approximately the same IOPS, which probably means that the backend upgrade is necessary anyway (as mentioned in https://github.com/longhorn/longhorn/issues/6600) to utilize the full potential of ublk and multistreams.

A full table of measurements is shown below. I used fio over one 1GB replica in a localhost enviroment.
CPU : Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
RAM: 16GB
Disk: Western Digital WD10EZEX 1TB

![image](https://github.com/longhorn/longhorn-engine/assets/45532178/6b7415b5-9e4d-4c80-bb4b-6034123c84d0)

#### Special notes for your reviewer:

In order to replicate the results you will need my version of ubdsrv installed: https://github.com/Kampadais/ubdsrv

To run the controller with ublk frontend, 6 frontend queues and 6 replica-streams: 
`./longhorn controller test --frontend ublk --size 1g --current-size 1g --frontend-queues 6 --replica-streams 6  --replica tcp://localhost:9502
`

The fio command used for testing:
`sudo fio --name=read_iops --filename=/dev/ublkb0 --size=5G --numjobs=12 --time_based --runtime=30s --ramp_time=2s --ioengine=libaio --direct=1 --verify=0 --bs=4K --iodepth=64 --rw=randwrite --group_reporting=1
`

We are still the need of a go-ublk-helper because the whole startup procedure is within the frontend.go file and monitoring status is limited.  There is also a limitation regarding the name of the block device provided by ublk.

#### Additional documentation or context

#


