### PR TITLE
Fix some v1 data path bottlenecks

### DIFF
--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	PingInterval = 2 * time.Second
+	PingInterval        = 2 * time.Second
+	NumberOfConnections = 2
 )
 
 func New() types.BackendFactory {
@@ -406,12 +407,16 @@ func (rf *Factory) Create(volumeName, address string, dataServerProtocol types.D
 		return nil, fmt.Errorf("replica must be closed, cannot add in state: %s", replica.State)
 	}
 
-	conn, err := connect(dataServerProtocol, dataAddress)
-	if err != nil {
-		return nil, err
+	var conns []net.Conn
+	for i := 0; i < NumberOfConnections; i++ {
+		conn, err := connect(dataServerProtocol, dataAddress)
+		if err != nil {
+			return nil, err
+		}
+		conns = append(conns, conn)
 	}
 
-	dataConnClient := dataconn.NewClient(conn, engineToReplicaTimeout)
+	dataConnClient := dataconn.NewClient(conns, engineToReplicaTimeout)
 	r.ReaderWriterUnmapperAt = dataConnClient
 
 	if err := r.open(); err != nil {


### PR DESCRIPTION
1. Improve revision counter logic
2. Increase the connection from engine to replica

Please see the improvement test result in the issue description at longhorn/longhorn#8436

longhorn/longhorn#8436

TODO:
- [ ] Do we need to make the number of connections from engine to replica customizable so user can adjust it for their particular env?

