### PR TITLE
Fix(v1.5.6): CVE issue from dependent longhorn-instance-manager binary

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -134,7 +134,7 @@ RUN cd integration && \
 RUN cd /go/src/github.com/longhorn && \
     git clone https://github.com/longhorn/longhorn-instance-manager.git && \
     cd longhorn-instance-manager && \
-    git checkout v1_20210731 && \
+    git checkout v1.5.x && \
     go build -o ./longhorn-instance-manager && \
     cp -r integration/rpc/ ${DAPPER_SOURCE}/integration/rpc/ && \
     cp longhorn-instance-manager /usr/local/bin

--- a/integration/common/cli.py
+++ b/integration/common/cli.py
@@ -8,7 +8,7 @@ from common.constants import (
     INSTANCE_MANAGER_REPLICA, INSTANCE_MANAGER_ENGINE,
 )
 
-from rpc.instance_manager.process_manager_client import ProcessManagerClient
+from rpc.imrpc.process_manager_client import ProcessManagerClient
 
 
 @pytest.fixture()

--- a/integration/common/constants.py
+++ b/integration/common/constants.py
@@ -1,14 +1,13 @@
 import os
 
 INSTANCE_MANAGER_REPLICA = "localhost:8500"
-INSTANCE_MANAGER_ENGINE = "localhost:8501"
+INSTANCE_MANAGER_ENGINE = "localhost:8505"
 
 INSTANCE_MANAGER_TYPE_ENGINE = "engine"
 INSTANCE_MANAGER_TYPE_REPLICA = "replica"
 
-LONGHORN_BINARY = "./bin/longhorn"
-BINARY_PATH_IN_TEST = "../bin/longhorn"
-LONGHORN_UPGRADE_BINARY = '/opt/longhorn'
+LONGHORN_BINARY = "/engine-binaries/bin/longhorn"
+LONGHORN_UPGRADE_BINARY = '/engine-binaries/opt/longhorn'
 
 LONGHORN_DEV_DIR = '/dev/longhorn'
 LONGHORN_SOCKET_DIR = '/var/run'

--- a/integration/common/frontend.py
+++ b/integration/common/frontend.py
@@ -5,12 +5,14 @@ import mmap
 import directio
 
 from common.constants import (
-    LONGHORN_SOCKET_DIR, LONGHORN_DEV_DIR, PAGE_SIZE,
+    LONGHORN_SOCKET_DIR,
+    LONGHORN_DEV_DIR,
+    PAGE_SIZE,
 )
 
 
 def readat_direct(dev, offset, length):
-    pg = offset / PAGE_SIZE
+    pg = offset // PAGE_SIZE
     in_page_offset = offset % PAGE_SIZE
     # either read less than a page, or whole pages
     if in_page_offset != 0:
@@ -27,7 +29,7 @@ def readat_direct(dev, offset, length):
         ret = directio.read(f, to_read)
     finally:
         os.close(f)
-    return ret[in_page_offset: in_page_offset + length]
+    return ret[in_page_offset : in_page_offset + length]
 
 
 def writeat_direct(dev, offset, data):
@@ -46,7 +48,7 @@ def writeat_direct(dev, offset, data):
         pg_data = readat_direct(dev, pg_offset, PAGE_SIZE)
         m.write(pg_data)
         m.seek(offset % PAGE_SIZE)
-        m.write(data.encode('utf-8'))
+        m.write(data.encode("utf-8"))
         ret = directio.write(f, m[:PAGE_SIZE])
     finally:
         m.close()
@@ -63,13 +65,12 @@ def get_block_device_path(volume):
 
 
 class blockdev:
-
     def __init__(self, volume):
         self.dev = get_block_device_path(volume)
 
     def readat(self, offset, length):
         assert self.ready()
-        with open(self.dev, 'r') as f:
+        with open(self.dev, "r") as f:
             f.seek(offset)
             ret = f.read(length)
         return ret

--- a/integration/core/conftest.py
+++ b/integration/core/conftest.py
@@ -15,7 +15,7 @@ from common.constants import (
 
 from rpc.controller.controller_client import ControllerClient
 from rpc.replica.replica_client import ReplicaClient
-from rpc.instance_manager.process_manager_client import ProcessManagerClient
+from rpc.imrpc.process_manager_client import ProcessManagerClient
 
 
 @pytest.fixture

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -55,7 +55,7 @@ from common.util import (
 
 from rpc.controller.controller_client import ControllerClient
 from rpc.replica.replica_client import ReplicaClient
-from rpc.instance_manager.process_manager_client import ProcessManagerClient
+from rpc.imrpc.process_manager_client import ProcessManagerClient
 
 VOLUME_HEAD = "volume-head"
 

--- a/integration/data/conftest.py
+++ b/integration/data/conftest.py
@@ -17,7 +17,7 @@ from common.constants import FRONTEND_TGT_BLOCKDEV
 from common.constants import FIXED_REPLICA_PATH1
 from common.constants import FIXED_REPLICA_PATH2
 from common.constants import \
-    BACKING_FILE_QCOW2_PATH1, BACKING_FILE_QCOW2_PATH2,\
+    BACKING_FILE_QCOW2_PATH1, BACKING_FILE_QCOW2_PATH2, \
     BACKING_FILE_RAW_PATH1, BACKING_FILE_RAW_PATH2
 
 from common.core import cleanup_replica
@@ -30,7 +30,7 @@ from common.core import get_dev
 from common.core import get_controller_version_detail
 
 
-from rpc.instance_manager.process_manager_client import ProcessManagerClient
+from rpc.imrpc.process_manager_client import ProcessManagerClient
 from rpc.replica.replica_client import ReplicaClient
 from rpc.controller.controller_client import ControllerClient
 

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -94,12 +94,19 @@ qemu-img convert -f raw -O qcow2 $backing_raw $backing_qcow2
 cp $backing_qcow2 $backing_dir1
 cp $backing_qcow2 $backing_dir2
 
-# for live upgrade test
-cp -a ./bin/longhorn /opt/
+# longhorn only accept binaries from dictories /engine-binaries/ and /host/var/lib/longhorn/engine-binaries/
+# ref: https://github.com/longhorn/longhorn-instance-manager/blob/3e8877e77b2238cec06636c5932e41e719840c03/pkg/process/process_manager.go#L129-L136
+mkdir -p /engine-binaries/bin/
+cp -a ./bin/longhorn /engine-binaries/bin/
 
-/usr/local/bin/longhorn-instance-manager --debug daemon &
+# for live upgrade test
+mkdir -p /engine-binaries/opt/
+cp -a ./bin/longhorn /engine-binaries/opt/
+
+/usr/local/bin/longhorn-instance-manager --debug daemon --listen localhost:8500 &
 pid_imr=$!
-/usr/local/bin/longhorn-instance-manager --debug daemon --listen localhost:8501 --port-range 30001-32000 &
+# longhorn-instance-manager use 5 ports, so the second instance manager starts from 8505
+/usr/local/bin/longhorn-instance-manager --debug daemon --listen localhost:8505 --port-range 30001-32000 &
 pid_ime=$!
 
 # make sure everything is running before continue integration test


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue `None`

#### What this PR does / why we need it:

Update the dependent instance-manager binary build to address the CVE vulnerabilities.

#### Special notes for your reviewer:

- The binary is required for launch-simple-file
- This is already addressed on v1.6.x and master branches because they do not use a specific branch.
https://github.com/longhorn/longhorn-engine/blob/v1.6.x/Dockerfile.dapper#L138-L143

#### Additional documentation or context

`None`
