### PR TITLE
fix(replica): best-effort to delete old head disk file

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -920,8 +920,9 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	rollbackFuncList := []func() error{}
 	defer func() {
 		if err == nil {
-			err = r.rmDisk(oldHead)
-			logrus.WithError(err).Errorf("Failed to remove old head %v", oldHead)
+			if errRm := r.rmDisk(oldHead); errRm != nil {
+				logrus.WithError(errRm).Warnf("Failed to remove old head %v", oldHead)
+			}
 			return
 		}
 


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9168

#### What this PR does / why we need it:

The deletion of old head disk file is a best-effort task, and the failure should not hinder the following tasks.

The regression is caused by the [commit](https://github.com/longhorn/longhorn-engine/commit/737bf77b6e0f01e68dbb340e4b3421bb0c7417b6#diff-b54af9ffed94a317525bc7609415261b623020d2aa410c124e9fe3b871d2d2bdR918).



#### Special notes for your reviewer:

#### Additional documentation or context
