### PR TITLE
feat: support a different timeout for the last replica

### DIFF
--- a/app/cmd/controller.go
+++ b/app/cmd/controller.go
@@ -145,10 +145,10 @@ func startController(c *cli.Context) error {
 	timeout := c.Int64("engine-replica-timeout")
 	engineReplicaTimeoutShort := time.Duration(timeout) * time.Second
 	engineReplicaTimeoutShort = controller.DetermineEngineReplicaTimeout(engineReplicaTimeoutShort)
-	// At the conclusion of https://github.com/longhorn/longhorn/issues/8711 we should have a strategy for determining
-	// engineReplicaTimeoutLong. For now, we set it to engineReplicaTimeoutShort to maintain existing behavior and
-	// modify it here for testing.
-	engineReplicaTimeoutLong := engineReplicaTimeoutShort
+	// In https://github.com/longhorn/longhorn/issues/8711 we decided to allow the last replica twice as long as the
+	// others before a timeout. We can optionally adjust this strategy (e.g. to a fixed sixty seconds or some
+	// configurable value) in the future.
+	engineReplicaTimeoutLong := 2 * engineReplicaTimeoutShort
 	iscsiTargetRequestTimeout := controller.DetermineIscsiTargetRequestTimeout(engineReplicaTimeoutLong)
 
 	snapshotMaxCount := c.Int("snapshot-max-count")

--- a/pkg/backend/dynamic/dynamic.go
+++ b/pkg/backend/dynamic/dynamic.go
@@ -3,7 +3,6 @@ package dynamic
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/longhorn/longhorn-engine/pkg/types"
 )
@@ -18,12 +17,13 @@ func New(factories map[string]types.BackendFactory) types.BackendFactory {
 	}
 }
 
-func (d *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration) (types.Backend, error) {
+func (d *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol,
+	sharedTimeouts types.SharedTimeouts) (types.Backend, error) {
 	parts := strings.SplitN(address, "://", 2)
 
 	if len(parts) == 2 {
 		if factory, ok := d.factories[parts[0]]; ok {
-			return factory.Create(volumeName, parts[1], dataServerProtocol, engineToReplicaTimeout)
+			return factory.Create(volumeName, parts[1], dataServerProtocol, sharedTimeouts)
 		}
 	}
 

--- a/pkg/backend/file/file.go
+++ b/pkg/backend/file/file.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -132,7 +131,8 @@ func (f *Wrapper) SetSnapshotMaxSize(size int64) error {
 	return nil
 }
 
-func (ff *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration) (types.Backend, error) {
+func (ff *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol,
+	sharedTimeouts types.SharedTimeouts) (types.Backend, error) {
 	logrus.Infof("Creating file: %s", address)
 	file, err := os.OpenFile(address, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {

--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -51,6 +51,12 @@ type Remote struct {
 
 func (r *Remote) Close() error {
 	logrus.Infof("Closing: %s", r.name)
+
+	// Close the dataconn client to avoid orphaning goroutines.
+	if dataconnClient, ok := r.ReaderWriterUnmapperAt.(*dataconn.Client); ok {
+		dataconnClient.Close()
+	}
+
 	conn, err := grpc.NewClient(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
 		interceptor.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {

--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -383,7 +383,8 @@ func (r *Remote) info() (*types.ReplicaInfo, error) {
 	return replicaClient.GetReplicaInfo(resp.Replica), nil
 }
 
-func (rf *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol, engineToReplicaTimeout time.Duration) (types.Backend, error) {
+func (rf *Factory) Create(volumeName, address string, dataServerProtocol types.DataServerProtocol,
+	sharedTimeouts types.SharedTimeouts) (types.Backend, error) {
 	logrus.Infof("Connecting to remote: %s (%v)", address, dataServerProtocol)
 
 	controlAddress, dataAddress, _, _, err := util.GetAddresses(volumeName, address, dataServerProtocol)
@@ -419,7 +420,7 @@ func (rf *Factory) Create(volumeName, address string, dataServerProtocol types.D
 		conns = append(conns, conn)
 	}
 
-	dataConnClient := dataconn.NewClient(conns, engineToReplicaTimeout)
+	dataConnClient := dataconn.NewClient(conns, sharedTimeouts)
 	r.ReaderWriterUnmapperAt = dataConnClient
 
 	if err := r.open(); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -109,7 +109,14 @@ type Backend interface {
 }
 
 type BackendFactory interface {
-	Create(volumeName, address string, dataServerProtocol DataServerProtocol, engineReplicaTimeout time.Duration) (Backend, error)
+	Create(volumeName, address string, dataServerProtocol DataServerProtocol,
+		sharedTimeouts SharedTimeouts) (Backend, error)
+}
+
+type SharedTimeouts interface {
+	Increment()
+	Decrement()
+	CheckAndDecrement(duration time.Duration) time.Duration
 }
 
 type Controller interface {

--- a/pkg/util/shared_timeouts.go
+++ b/pkg/util/shared_timeouts.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"sync"
+	"time"
+)
+
+// SharedTimeouts has the following use case:
+// - Multiple goroutines may need to time out eventually.
+// - Only the goroutines themselves know if the conditions for a timeout have been met.
+// - It is fine for some of the goroutines to time out quickly.
+// - The last goroutine should time out more slowly.
+// SharedTimeouts implements the types.SharedTimeouts instead of directly defining the concrete type to avoid an import
+// loop.
+type SharedTimeouts struct {
+	mutex        sync.RWMutex
+	longTimeout  time.Duration
+	shortTimeout time.Duration
+	numConsumers int
+}
+
+func NewSharedTimeouts(shortTimeout, longTimeout time.Duration) *SharedTimeouts {
+	return &SharedTimeouts{
+		longTimeout:  longTimeout,
+		shortTimeout: shortTimeout,
+	}
+}
+
+func (t *SharedTimeouts) Increment() {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.numConsumers++
+}
+
+func (t *SharedTimeouts) Decrement() {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.numConsumers--
+}
+
+// CheckAndDecrement checks if duration exceeds longTimeout or shortTimeout, returns the timeout exceeded (if
+// applicable) and decrements numConsumers.
+// - shortTimeout is only considered exceeded if there is still one other consumer to wait for longTimeout.
+// - The caller MUST take whatever action is required for a timeout if a value > 0 is returned.
+func (t *SharedTimeouts) CheckAndDecrement(duration time.Duration) time.Duration {
+	if duration > t.longTimeout {
+		t.mutex.Lock()
+		defer t.mutex.Unlock()
+		t.numConsumers--
+		return t.longTimeout
+	}
+
+	if duration > t.shortTimeout {
+		t.mutex.Lock()
+		defer t.mutex.Unlock()
+		if t.numConsumers > 1 {
+			t.numConsumers--
+			return t.shortTimeout
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8711

#### What this PR does / why we need it:

The implementation in this PR makes it possible to configure the engine so that there are two `engineReplicaTimeouts` (short and long). The backends lightly coordinate via a new `SharedTimeouts` struct to ensure that most of them can time out in the normal way after `engineReplicaTimeoutShort`, but exactly one of them must wait `engineReplicaTimeoutLong` to do the same.

~Note that this PR does NOT actually configure a different `engineReplicaTimeoutLong`. My plan is to do that in a followup after this one is approved and we decide exactly how we want to expose the new capability.~

#### Special notes for your reviewer:

#### Additional documentation or context

Per https://github.com/longhorn/longhorn-engine/pull/1176#issuecomment-2274190148, I experimented with a different approach in https://github.com/ejweber/longhorn-engine/tree/8711-last-replica-timeout-previous-attempt. That one didn't work well due to lock contention between I/O operations, replica error handling, and the new logic.