### PR TITLE
fix(backup): skip loading the backingFile when doing backup or when user requests exporting the volume without backingFile

### DIFF
--- a/pkg/replica/diff_disk.go
+++ b/pkg/replica/diff_disk.go
@@ -20,7 +20,7 @@ type diffDisk struct {
 	// we don't know the location yet.
 	location []byte
 	// list of files in grandparent, parent, child, etc order.
-	// index 0 is nil or backing file and index n-1 is the active write layer
+	// index 0 is nil, index 1 is backing file, and index n-1 is the active write layer
 	files      []types.DiffDisk
 	sectorSize int64
 	// current size of the head file.
@@ -372,9 +372,14 @@ func (d *diffDisk) initializeSectorLocation(value byte) {
 	}
 }
 
-func (d *diffDisk) preload() error {
+func (d *diffDisk) preload(isThereBackingFile bool) error {
 	for i, f := range d.files {
 		if i == 0 {
+			continue
+		}
+
+		// Skip loading the backingFile if it exists
+		if i == int(backingFileIndex) && isThereBackingFile {
 			continue
 		}
 

--- a/pkg/replica/extents.go
+++ b/pkg/replica/extents.go
@@ -11,11 +11,6 @@ const MaxExtentsBuffer = 1024
 func LoadDiffDiskLocationList(diffDisk *diffDisk, disk types.DiffDisk, currentFileIndex byte) error {
 	fd := disk.Fd()
 
-	// The backing file will have a Fd of 0
-	if fd == 0 {
-		return nil
-	}
-
 	start := uint64(0)
 	end := uint64(len(diffDisk.location)) * uint64(diffDisk.sectorSize)
 	for {

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -1467,7 +1467,8 @@ func (r *Replica) Preload(includeBackingFileLayer bool) error {
 	} else {
 		r.volume.initializeSectorLocation(nilFileIndex)
 	}
-	return r.volume.preload()
+	isThereBackingFile := r.info.BackingFile != nil
+	return r.volume.preload(isThereBackingFile)
 }
 
 func (r *Replica) GetDataLayout(ctx context.Context) (<-chan sparse.FileInterval, <-chan error, error) {


### PR DESCRIPTION
@ChanYiLin has awesome analysis that sometime we are still loading backing file layer on sle-micro ARM64 when doing backup [link](https://github.com/longhorn/longhorn/issues/9209#issuecomment-2284142447). This is not correct because we should skip loading backing file when doing backup 


The current implementation relies on the assumption that file descriptor of backingFile is always 0 and uses it to skip loading the backingFile layer: [link](https://github.com/longhorn/longhorn-engine/blob/04c645097a4a93e46f0f0391222895ea06b25456/pkg/replica/extents.go#L15-L18) . However, this assumption is not always correct. For example, with RAW backing image, `fd` is not 0. See more details at [link](https://github.com/longhorn/longhorn/issues/9209#issuecomment-2285219668) . For qcow backing image, that assumption is correct because qcow image has hard coded to have FD 0 here https://github.com/longhorn/longhorn-engine/blob/04c645097a4a93e46f0f0391222895ea06b25456/pkg/qcow/libqcow.go#L84-L87


This PR propose a this fix which always skip loading backingFile and doesn't rely on the assumption that backing file has `fd` as `0`


longhorn/longhorn#9209

