### PR TITLE
fix(datconn): don't orphan client goroutine when remote is closed (backport #1176)

### DIFF
--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -47,6 +47,12 @@ type Remote struct {
 
 func (r *Remote) Close() error {
 	logrus.Infof("Closing: %s", r.name)
+
+	// Close the dataconn client to avoid orphaning goroutines.
+	if dataconnClient, ok := r.ReaderWriterUnmapperAt.(*dataconn.Client); ok {
+		dataconnClient.Close()
+	}
+
 	conn, err := grpc.NewClient(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
 		ptypes.WithIdentityValidationClientInterceptor(r.volumeName, ""))
 	if err != nil {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

We closed https://github.com/longhorn/longhorn-engine/pull/1199 but still want the fix for the potential orphan goroutine issue in v1.6.x.
