### PR TITLE
fix: skip updating the status if the backup has already completed or failed

### DIFF
--- a/pkg/replica/backup.go
+++ b/pkg/replica/backup.go
@@ -57,6 +57,11 @@ func (rb *BackupStatus) UpdateBackupStatus(snapID, volumeID string, state string
 		return fmt.Errorf("invalid volume [%s] and snapshot [%s], not volume [%s], snapshot [%s]", rb.volumeID, rb.SnapshotID, volumeID, id)
 	}
 
+	if rb.State == ProgressStateComplete || rb.State == ProgressStateError {
+		logrus.Warnf("backup of volume [%s] and snapshot [%s] already completed or failed, skip the status update", rb.volumeID, rb.SnapshotID)
+		return nil
+	}
+
 	rb.State = ProgressState(state)
 	rb.Progress = progress
 	rb.BackupURL = url


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9168

To prevent race conditions where some goroutines might update the status to 'In Progress' after the backup has already completed or failed, we should skip updating the status in such cases.