### PR TITLE
fix(logging): demote some Info logging to Debug

### DIFF
--- a/pkg/backend/remote/remote.go
+++ b/pkg/backend/remote/remote.go
@@ -96,7 +96,7 @@ func (r *Remote) open() error {
 }
 
 func (r *Remote) Snapshot(name string, userCreated bool, created string, labels map[string]string) error {
-	logrus.Infof("Starting to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
+	logrus.Debugf("Starting to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
 		r.name, name, userCreated, created, labels)
 	conn, err := grpc.NewClient(r.replicaServiceURL, grpc.WithTransportCredentials(insecure.NewCredentials()),
 		interceptor.WithIdentityValidationClientInterceptor(r.volumeName, ""))
@@ -117,7 +117,7 @@ func (r *Remote) Snapshot(name string, userCreated bool, created string, labels 
 	}); err != nil {
 		return errors.Wrapf(err, "failed to snapshot replica %v from remote", r.replicaServiceURL)
 	}
-	logrus.Infof("Finished to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
+	logrus.Debugf("Finished to snapshot: %s %s UserCreated %v Created at %v, Labels %v",
 		r.name, name, userCreated, created, labels)
 	return nil
 }

--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -200,7 +200,7 @@ func (c *Controller) Snapshot(inputName string, labels map[string]string, should
 	}
 
 	log := logrus.WithFields(logrus.Fields{"volume": c.VolumeName, "snapshot": name})
-	log.Info("Starting snapshot")
+	log.Debug("Starting snapshot")
 
 	defer func() {
 		if err != nil {
@@ -228,7 +228,7 @@ func (c *Controller) Snapshot(inputName string, labels map[string]string, should
 	exec := lhexec.NewExecutor()
 	defer func() {
 		if frozen {
-			log.Infof("Unfreezing filesystem mounted at %v", freezePoint)
+			log.Debugf("Unfreezing filesystem mounted at %v", freezePoint)
 			if _, err := util.UnfreezeFilesystem(freezePoint, exec); err != nil {
 				log.WithError(err).Warnf("Failed to unfreeze filesystem mounted at %v", freezePoint)
 			}
@@ -263,7 +263,7 @@ func (c *Controller) Snapshot(inputName string, labels map[string]string, should
 	}
 	if !frozen {
 		// Revert to the previous/default behavior of syncing before taking a snapshot.
-		log.Info("Requesting system sync before snapshot")
+		log.Debug("Requesting system sync before snapshot")
 		if err := lhns.Sync(); err != nil {
 			// Sync should never fail, so it is likely due to the nsenter. To maintain existing behavior, we do not
 			// refuse to take a snapshot if sync fails.
@@ -281,7 +281,7 @@ func (c *Controller) Snapshot(inputName string, labels map[string]string, should
 	if err = c.handleErrorNoLock(c.backend.Snapshot(name, true, created, labels)); err != nil {
 		return "", err
 	}
-	log.Info("Finished snapshot")
+	log.Debug("Finished snapshot")
 	return name, nil
 }
 

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -366,13 +366,13 @@ func (r *Replica) hardlinkDisk(target, source string) error {
 	}
 
 	if _, err := os.Stat(r.diskPath(target)); err == nil {
-		logrus.Infof("Removing old file %s", target)
+		logrus.Debugf("Removing old file %s", target)
 		if err := os.Remove(r.diskPath(target)); err != nil {
 			return errors.Wrapf(err, "failed to remove %s", target)
 		}
 	}
 
-	logrus.Infof("Hard linking %v to %v", source, target)
+	logrus.Debugf("Hard linking %v to %v", source, target)
 	if err := os.Link(r.diskPath(source), r.diskPath(target)); err != nil {
 		return fmt.Errorf("failed to hard link %s to %s", source, target)
 	}
@@ -413,7 +413,7 @@ func (r *Replica) ReplaceDisk(target, source string) error {
 	}
 	r.volume.files[index] = newFile
 
-	logrus.Infof("Done replacing disk %v with %v", source, target)
+	logrus.Debugf("Done replacing disk %v with %v", source, target)
 
 	return nil
 }
@@ -776,19 +776,19 @@ func (r *Replica) linkDisk(oldName, newName string) (rollbackFunc func() error, 
 	}()
 
 	destMetadata := r.diskPath(newName + diskutil.DiskMetadataSuffix)
-	logrus.Infof("Cleaning up new disk metadata file path %v before linking", destMetadata)
+	logrus.Debugf("Cleaning up new disk metadata file path %v before linking", destMetadata)
 	if err := os.RemoveAll(destMetadata); err != nil {
 		return rollbackFunc, errors.Wrapf(err, "failed to clean up new disk metadata file %v before linking", destMetadata)
 	}
 
 	destChecksum := r.diskPath(newName + diskutil.DiskChecksumSuffix)
-	logrus.Infof("Cleaning up new disk checksum file %v before linking", destChecksum)
+	logrus.Debugf("Cleaning up new disk checksum file %v before linking", destChecksum)
 	if err := os.RemoveAll(destChecksum); err != nil {
 		return rollbackFunc, errors.Wrapf(err, "failed to clean up new disk checksum file %v before linking", destChecksum)
 	}
 
 	dest := r.diskPath(newName)
-	logrus.Infof("Cleaning up new disk file %v before linking", dest)
+	logrus.Debugf("Cleaning up new disk file %v before linking", dest)
 	if err := os.RemoveAll(dest); err != nil {
 		return rollbackFunc, errors.Wrapf(err, "failed to clean up new disk file %v before linking", dest)
 	}
@@ -831,7 +831,7 @@ func (r *Replica) rmDisk(name string) error {
 		return nil
 	}
 
-	logrus.Infof("Removing disk %v", name)
+	logrus.Debugf("Removing disk %v", name)
 
 	diskPath := r.diskPath(name)
 	lastErr := os.RemoveAll(diskPath)
@@ -895,7 +895,7 @@ func (r *Replica) revertDisk(parentDiskFileName, created string) (*Replica, erro
 
 func (r *Replica) createDisk(name string, userCreated bool, created string, labels map[string]string, size int64) (err error) {
 	log := logrus.WithFields(logrus.Fields{"disk": name})
-	log.Info("Starting to create disk")
+	log.Debug("Starting to create disk")
 	if r.readOnly {
 		return fmt.Errorf("cannot create disk on read-only replica")
 	}
@@ -995,7 +995,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	r.volume.files = append(r.volume.files, f)
 	r.activeDiskData = append(r.activeDiskData, &newHeadDisk)
 
-	log.Info("Finished creating disk")
+	log.Debug("Finished creating disk")
 	return nil
 }
 
@@ -1229,7 +1229,7 @@ func (r *Replica) SetUnmapMarkDiskChainRemoved(enabled bool) {
 
 	r.unmapMarkDiskChainRemoved = enabled
 
-	logrus.Infof("Set replica flag unmapMarkDiskChainRemoved to %v", enabled)
+	logrus.Debugf("Set replica flag unmapMarkDiskChainRemoved to %v", enabled)
 }
 
 func (r *Replica) SetSnapshotMaxCount(count int) {
@@ -1238,7 +1238,7 @@ func (r *Replica) SetSnapshotMaxCount(count int) {
 
 	r.snapshotMaxCount = count
 
-	logrus.Infof("Set replica flag snapshotMaxCount to %d", count)
+	logrus.Debugf("Set replica flag snapshotMaxCount to %d", count)
 }
 
 func (r *Replica) SetSnapshotMaxSize(size int64) {
@@ -1247,7 +1247,7 @@ func (r *Replica) SetSnapshotMaxSize(size int64) {
 
 	r.snapshotMaxSize = size
 
-	logrus.Infof("Set replica flag SnapshotMaxSize to %d", size)
+	logrus.Debugf("Set replica flag SnapshotMaxSize to %d", size)
 }
 
 func (r *Replica) Expand(size int64) (err error) {

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -93,7 +93,7 @@ func (s *Server) Reload() error {
 		return nil
 	}
 
-	logrus.Info("Reloading replica")
+	logrus.Debug("Reloading replica")
 	newReplica, err := s.r.Reload()
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ func (s *Server) Revert(name, created string) error {
 		return nil
 	}
 
-	logrus.Infof("Reverting to snapshot [%s] on replica at %s", name, created)
+	logrus.Debugf("Reverting to snapshot [%s] on replica at %s", name, created)
 	r, err := s.r.Revert(name, created)
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (s *Server) Snapshot(name string, userCreated bool, createdTime string, lab
 		return nil
 	}
 
-	logrus.Infof("Replica server starts to snapshot [%s] volume, user created %v, created time %v, labels %v",
+	logrus.Debugf("Replica server starts to snapshot [%s] volume, user created %v, created time %v, labels %v",
 		name, userCreated, createdTime, labels)
 	return s.r.Snapshot(name, userCreated, createdTime, labels)
 }
@@ -228,7 +228,7 @@ func (s *Server) Expand(size int64) error {
 		return nil
 	}
 
-	logrus.Infof("Replica server starts to expand to size %v", size)
+	logrus.Debugf("Replica server starts to expand to size %v", size)
 
 	return s.r.Expand(size)
 }
@@ -241,7 +241,7 @@ func (s *Server) RemoveDiffDisk(name string, force bool) error {
 		return nil
 	}
 
-	logrus.Infof("Removing disk %s, force %v", name, force)
+	logrus.Debugf("Removing disk %s, force %v", name, force)
 	return s.r.RemoveDiffDisk(name, force)
 }
 
@@ -253,7 +253,7 @@ func (s *Server) ReplaceDisk(target, source string) error {
 		return nil
 	}
 
-	logrus.Infof("Replacing disk %v with %v", source, target)
+	logrus.Debugf("Replacing disk %v with %v", source, target)
 	return s.r.ReplaceDisk(target, source)
 }
 
@@ -265,7 +265,7 @@ func (s *Server) MarkDiskAsRemoved(name string) error {
 		return nil
 	}
 
-	logrus.Infof("Marking disk %v as removed", name)
+	logrus.Debugf("Marking disk %v as removed", name)
 	return s.r.MarkDiskAsRemoved(name)
 }
 
@@ -277,7 +277,7 @@ func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 		return nil, nil
 	}
 
-	logrus.Infof("Prepare removing disk %s", name)
+	logrus.Debugf("Prepare removing disk %s", name)
 	return s.r.PrepareRemoveDisk(name)
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Part of https://github.com/longhorn/longhorn/issues/6702

#### What this PR does / why we need it:

Demote some noisy Info-level logging to Debug.  Routine snapshotting can flood logs with Info-level output.

#### Special notes for your reviewer:

#### Additional documentation or context
