### PR TITLE
fix: not allow more than 250 snapshots including all kind of snapshots

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -1407,17 +1407,11 @@ func (r *Replica) GetSnapshotCountUsage() int {
 
 func (r *Replica) getSnapshotCountUsage() int {
 	var (
-		backingDiskName string
-		snapshotCount   int
+		snapshotCount int
 	)
-	// index 0 is nil or backing file
-	if r.activeDiskData[0] != nil {
-		backingDiskName = r.activeDiskData[0].Name
-	}
 
 	for _, disk := range r.diskData {
-		// exclude volume head, backing disk, and removed disks
-		if disk == nil || disk.Removed || disk.Name == backingDiskName || disk.Name == r.info.Head {
+		if disk == nil {
 			continue
 		}
 		snapshotCount++


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#10308

#### What this PR does / why we need it:

Not allow creation of more than 250 snapshots including all kind of snapshots (volume-head, backing image, removed snapshot, ...) because we use 8-bit map for snapshot indexing.


#### Special notes for your reviewer:

#### Additional documentation or context
