### PR TITLE
fix(ci): fixed project name for GHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PROJECT := longhorn-engine
 TARGETS := $(shell ls scripts)
 MACHINE := longhorn
 # Define the target platforms that can be used across the ecosystem.
@@ -30,9 +31,9 @@ buildx-machine:
 # - IID_FILE_FLAG: optional, options to generate image ID file
 .PHONY: workflow-image-build-push workflow-image-build-push-secure workflow-manifest-image
 workflow-image-build-push: buildx-machine
-	MACHINE=$(MACHINE) PUSH='true' bash scripts/package
+	MACHINE=$(MACHINE) PUSH='true' IMAGE_NAME=$(PROJECT) bash scripts/package
 workflow-image-build-push-secure: buildx-machine
-	MACHINE=$(MACHINE) PUSH='true' IS_SECURE=true bash scripts/package
+	MACHINE=$(MACHINE) PUSH='true' IMAGE_NAME=$(PROJECT) IS_SECURE=true bash scripts/package
 workflow-manifest-image:
 	docker pull --platform linux/amd64 ${REPO}/longhorn-engine:${TAG}-amd64
 	docker pull --platform linux/arm64 ${REPO}/longhorn-engine:${TAG}-arm64


### PR DESCRIPTION
This change corrects the image name for GHA, to decouple the name from build environment