### PR TITLE
fix: build failed

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -20,4 +20,4 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 go build -o bin/longhorn -tags netgo -ldflags "$LINKFLAGS" $COVER $COVERPKG
-[[ ! -x ./bin/longhorn-instance-manager ]] && cp /usr/local/bin/longhorn-instance-manager ./bin
+cp /usr/local/bin/longhorn-instance-manager ./bin


### PR DESCRIPTION
When `./bin/longhorn-instance-manager` file does exist, `[[ ! -x ./bin/longhorn-instance-manager ]]` evaluates to `false` and return exit code 1. Since `set -e` is enabled, the script immediately exits on this failure.

Always copy and overwrite the `./bin/longhorn-instance-manager` if it exists

