### PR TITLE
fix: rebuilding gets stuck if verification fails and longhorn-manager crashes

### DIFF
--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -430,6 +430,7 @@ func (s *SyncAgentServer) FilesSync(ctx context.Context, req *enginerpc.FilesSyn
 			s.RebuildStatus.State = types.ProcessStateError
 			logrus.WithError(err).Error("Sync agent gRPC server failed to rebuild replica/sync files")
 		} else {
+			s.RebuildStatus.Progress = 100
 			s.RebuildStatus.State = types.ProcessStateComplete
 			logrus.Infof("Sync agent gRPC server finished rebuilding replica/sync files for replica %v", req.ToHost)
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8589

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/8589#issuecomment-2679915554

#### Special notes for your reviewer:

#### Additional documentation or context
