### PR TITLE
feat(ci): enable CI validation for arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,14 +80,14 @@ jobs:
     - name: Install make curl git
       run: |
         sudo apt update
-        sudo apt-get -y install make curl git
+        sudo apt-get -y install make curl git open-iscsi
 
     - name: Checkout code
       uses: actions/checkout@v4
 
     # Build binaries
-    - name: Run make build
-      run: make build
+    - name: Run make ci
+      run: SKIP_TASKS=package make ci
 
     - name: Upload binaries
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Enable whole CI steps while building binary for arm64, include:

- validate
- sync-grpc-py
- test
- integration-test
