### PR TITLE
chore(dockerfile): pin build runner image to ubuntu:latest and install missing e2fsprogs package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   build-arm64-binaries:
     name: Build ARM64 binaries
-    runs-on: longhorn-infra-oracle-arm64-runners
+    runs-on: ubuntu-latest
     steps:
     - name: Install make curl git
       run: |
@@ -141,7 +141,7 @@ jobs:
 
   build-push-arm64-images:
     name: Build and push ARM64 images
-    runs-on: longhorn-infra-oracle-arm64-runners
+    runs-on: ubuntu-latest
     needs: [build_info, build-arm64-binaries]
     if: ${{ startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/') }}
     steps:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -40,7 +40,7 @@ RUN zypper -n install cmake curl git less file gcc python311 python311-pip pytho
     bash-completion librdmacm1 librdmacm-utils libibverbs xsltproc docbook-xsl-stylesheets \
     perl-Config-General libaio-devel glibc-devel-static glibc-devel sg3_utils iptables libltdl7 \
     libdevmapper1_03 iproute2 jq unzip zlib-devel zlib-devel-static \
-    rpm-build rdma-core-devel gcc-c++ docker open-iscsi && \
+    rpm-build rdma-core-devel gcc-c++ docker open-iscsi e2fsprogs && \
     rm -rf /var/cache/zypp/*
 
 # Install golangci-lint


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

- pin build runner image to ubuntu:latest
- chattr utility is not found because e2fsprogs package is not existing in the latest ubuntu:22.04 and ubuntu:24.04 runner images 

#### Special notes for your reviewer:

#### Additional documentation or context
