### PR TITLE
fix: handle 'no space left on device' error

### DIFF
--- a/pkg/dataconn/server.go
+++ b/pkg/dataconn/server.go
@@ -112,6 +112,10 @@ func (s *Server) pushResponse(count int, msg *Message, err error) {
 		msg.Type = TypeEOF
 		msg.Data = msg.Data[:count]
 		msg.Size = uint32(len(msg.Data))
+	} else if err == types.ErrNoSpaceLeftOnDevice {
+		msg.Type = TypeENOSPC
+		msg.Data = []byte(err.Error())
+		msg.Size = uint32(len(msg.Data))
 	} else if err != nil {
 		msg.Type = TypeError
 		msg.Data = []byte(err.Error())

--- a/pkg/dataconn/types.go
+++ b/pkg/dataconn/types.go
@@ -11,6 +11,7 @@ const (
 	TypeClose
 	TypePing
 	TypeUnmap
+	TypeENOSPC
 
 	messageSize     = (32 + 32 + 32 + 64) / 8 //TODO: unused?
 	readBufferSize  = 8096

--- a/pkg/types/error.go
+++ b/pkg/types/error.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/status"
@@ -18,7 +19,11 @@ const (
 
 const (
 	CannotRequestHashingSnapshotPrefix = "cannot request hashing snapshot"
+
+	ErrorStringNoSpaceLeftOnDevice = "no space left on device"
 )
+
+var ErrNoSpaceLeftOnDevice = errors.New(ErrorStringNoSpaceLeftOnDevice)
 
 type Error struct {
 	Code            ErrorCode `json:"code"`


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10718

#### What this PR does / why we need it:

Return the `no space left on device` error to `liblonghorn`. Then `tgt` handles this error type and returns a corresponding error to the host.

#### Special notes for your reviewer:

#### Additional documentation or context
Regression test:
https://10.115.5.5/job/private/job/longhorn-tests-regression/171/
