### PR TITLE
feat: increase the timeout of tgt's timeout_handler

### DIFF
--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -550,7 +550,7 @@ func (c *Controller) setReplicaModeNoLock(address string, mode types.Mode) {
 				c.replicas[i] = r
 				c.backend.SetMode(address, mode)
 			} else {
-				log.Infof("Ignore set replica %v to mode %v due to it's ERR", address, mode)
+				log.Infof("Ignored setting replica %v to mode %v due to it's ERR", address, mode)
 			}
 		}
 	}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8572

#### What this PR does / why we need it:

To reduce the chance of hitting the read-only issue, the key is to properly tune the timeout setting for the tgt’s timeout_handler. Because the SCSI layer limits the number of outstanding write requests, this ensures that in-flight requests have sufficient time to complete rather than being prematurely terminated.

#### Special notes for your reviewer:

#### Additional documentation or context
