### PR TITLE
fix(replica): validate size with backing image virtual size

### DIFF
--- a/app/cmd/replica.go
+++ b/app/cmd/replica.go
@@ -133,6 +133,9 @@ func startReplica(c *cli.Context) (err error) {
 		if err != nil {
 			return err
 		}
+		if backingFile != nil && size < backingFile.VirtualSize {
+			return fmt.Errorf("replica size %v < backing image virtual size %v", size, backingFile.VirtualSize)
+		}
 
 		if err := s.Create(size); err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297
-	github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8
+	github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa
 	github.com/longhorn/go-iscsi-helper v0.0.0-20250810143507-5c5f9a0060b4
 	github.com/longhorn/sparse-tools v0.0.0-20250826041019-4aae87cb253a
 	github.com/longhorn/types v0.0.0-20250831081209-ea63b0b5f6e1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297 h1:KVnOHFT3wuwgyhV7/Rue8NMt13NkpIkZ3B7eVR0C8yM=
 github.com/longhorn/backupstore v0.0.0-20250804022317-794abf817297/go.mod h1:j5TiUyvRBYaSaPY/p6GIFOk1orfWcngk9hIWxDDJ5mg=
-github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8 h1:4BTTTrkY/6XoibNhkdTkrh4LTB8cYGvuDhaZCan+SIc=
-github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8/go.mod h1:8acAlt4F+Dgyq923/i2pNpZI+LX7XW75BpPzxe1TXJE=
+github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa h1:90B+2eTb+qGlmzWosRbFr0IGK48/9T5z9drEey1DRw0=
+github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa/go.mod h1:8acAlt4F+Dgyq923/i2pNpZI+LX7XW75BpPzxe1TXJE=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250810143507-5c5f9a0060b4 h1:i6Wac1SO2YwXkqZetnc1KZc+2PnFZ9xSUs99nFAhHiU=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250810143507-5c5f9a0060b4/go.mod h1:EIkghFAyqv+8ktznS4a+leJ6KKQLPt9zrcdS2Zsfk+M=
 github.com/longhorn/sparse-tools v0.0.0-20250826041019-4aae87cb253a h1:uiECueW4EyOjfaw0GgKlbJjAjDBgQlsDiQjXDU262VY=

--- a/pkg/backingfile/backingfile.go
+++ b/pkg/backingfile/backingfile.go
@@ -1,15 +1,12 @@
 package backingfile
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
-	"syscall"
 
 	"github.com/longhorn/sparse-tools/sparse"
+
+	"github.com/longhorn/go-common-libs/backingimage"
 
 	"github.com/longhorn/longhorn-engine/pkg/qcow"
 	"github.com/longhorn/longhorn-engine/pkg/types"
@@ -18,55 +15,11 @@ import (
 )
 
 type BackingFile struct {
-	Size       int64
-	SectorSize int64
-	Path       string
-	Disk       types.DiffDisk
-}
-
-func detectFileFormat(file string) (string, error) {
-
-	/* Example command outputs
-	   $ qemu-img info parrot.raw
-	   image: parrot.raw
-	   file format: raw
-	   virtual size: 32M (33554432 bytes)
-	   disk size: 2.2M
-
-	   $ qemu-img info parrot.qcow2
-	   image: parrot.qcow2
-	   file format: qcow2
-	   virtual size: 32M (33554432 bytes)
-	   disk size: 2.3M
-	   cluster_size: 65536
-	   Format specific information:
-	       compat: 1.1
-	       lazy refcounts: false
-	       refcount bits: 16
-	       corrupt: false
-	*/
-
-	cmd := exec.Command("qemu-img", "info", file)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGKILL,
-	}
-	var output, stderr bytes.Buffer
-	cmd.Stdout = &output
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to check backing file format with command [qume-img info %v], output %s, stderr, %s, error %v",
-			file, output.String(), stderr.String(), err)
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(output.String()))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "file format: ") {
-			return strings.TrimPrefix(line, "file format: "), nil
-		}
-	}
-
-	return "", fmt.Errorf("cannot find the file format in the output %s", output.String())
+	Size        int64
+	VirtualSize int64
+	SectorSize  int64
+	Path        string
+	Disk        types.DiffDisk
 }
 
 func OpenBackingFile(file string) (*BackingFile, error) {
@@ -78,13 +31,14 @@ func OpenBackingFile(file string) (*BackingFile, error) {
 		return nil, err
 	}
 
-	format, err := detectFileFormat(file)
+	imageToolExec := backingimage.NewQemuImgExecutor()
+	imageInfo, err := imageToolExec.GetImageInfo(file)
 	if err != nil {
 		return nil, err
 	}
 
 	var f types.DiffDisk
-	switch format {
+	switch imageInfo.Format {
 	case "qcow2":
 		if f, err = qcow.Open(file); err != nil {
 			return nil, err
@@ -94,7 +48,7 @@ func OpenBackingFile(file string) (*BackingFile, error) {
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("format %v of the backing file %v is not supported", format, file)
+		return nil, fmt.Errorf("format %v of the backing file %v is not supported", imageInfo.Format, file)
 	}
 
 	size, err := f.Size()
@@ -106,9 +60,10 @@ func OpenBackingFile(file string) (*BackingFile, error) {
 	}
 
 	return &BackingFile{
-		Path:       file,
-		Disk:       f,
-		Size:       size,
-		SectorSize: diskutil.BackingImageSectorSize,
+		Path:        file,
+		Disk:        f,
+		Size:        size,
+		VirtualSize: imageInfo.VirtualSize,
+		SectorSize:  diskutil.BackingImageSectorSize,
 	}, nil
 }

--- a/vendor/github.com/longhorn/go-common-libs/backingimage/backingimage.go
+++ b/vendor/github.com/longhorn/go-common-libs/backingimage/backingimage.go
@@ -1,0 +1,81 @@
+package backingimage
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/longhorn/go-common-libs/exec"
+)
+
+const (
+	QemuImgBinary = "qemu-img"
+)
+
+type ImageInfo struct {
+	Format string `json:"format"`
+
+	// physical image file size on disk
+	ActualSize int64 `json:"actual-size"`
+	// claimed size of the guest disk.
+	// For qcow2 files, VirtualSize may be larger than the physical image file size on disk.
+	// For raw files, `qemu-img info` will report VirtualSize as being the same as the ActualSize.
+	VirtualSize int64 `json:"virtual-size"`
+}
+
+type QemuImgExecutor struct {
+	exec exec.ExecuteInterface
+}
+
+func NewQemuImgExecutor() *QemuImgExecutor {
+	return newQemuImgExecutor(exec.NewExecutor())
+}
+
+func newQemuImgExecutor(exec exec.ExecuteInterface) *QemuImgExecutor {
+	return &QemuImgExecutor{exec: exec}
+}
+
+func (ex *QemuImgExecutor) Exec(envs []string, args ...string) (string, error) {
+	return ex.exec.Execute(envs, QemuImgBinary, args, time.Minute)
+}
+
+func (ex *QemuImgExecutor) GetImageInfo(filePath string) (imgInfo ImageInfo, err error) {
+
+	/* Example command outputs
+	   $ qemu-img info --output=json SLE-Micro.x86_64-5.5.0-Default-qcow-GM.qcow2
+	   {
+	       "virtual-size": 21474836480,
+	       "filename": "SLE-Micro.x86_64-5.5.0-Default-qcow-GM.qcow2",
+	       "cluster-size": 65536,
+	       "format": "qcow2",
+	       "actual-size": 1001656320,
+	       "format-specific": {
+	           "type": "qcow2",
+	           "data": {
+	               "compat": "1.1",
+	               "compression-type": "zlib",
+	               "lazy-refcounts": false,
+	               "refcount-bits": 16,
+	               "corrupt": false,
+	               "extended-l2": false
+	           }
+	       },
+	       "dirty-flag": false
+	   }
+
+	   $ qemu-img info --output=json SLE-15-SP5-Full-x86_64-GM-Media1.iso
+	   {
+	       "virtual-size": 14548992000,
+	       "filename": "SLE-15-SP5-Full-x86_64-GM-Media1.iso",
+	       "format": "raw",
+	       "actual-size": 14548996096,
+	       "dirty-flag": false
+	   }
+	*/
+
+	output, err := ex.Exec([]string{}, "info", "--output=json", filePath)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal([]byte(output), &imgInfo)
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,8 +178,9 @@ github.com/longhorn/backupstore/systembackup
 github.com/longhorn/backupstore/types
 github.com/longhorn/backupstore/util
 github.com/longhorn/backupstore/vfs
-# github.com/longhorn/go-common-libs v0.0.0-20250831092333-eaa5dddf05b8
+# github.com/longhorn/go-common-libs v0.0.0-20250905093241-e9576a7c89fa
 ## explicit; go 1.24.0
+github.com/longhorn/go-common-libs/backingimage
 github.com/longhorn/go-common-libs/backup
 github.com/longhorn/go-common-libs/exec
 github.com/longhorn/go-common-libs/io


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11362

#### What this PR does / why we need it:

To reject backed replica creation if the size is less than the backing image virtual size.

#### Special notes for your reviewer:

This PR depends on longhorn/go-common-libs/pull/132

#### Additional documentation or context
