### PR TITLE
chore: update pinned stale workflow SHA

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   call-workflow:
-    uses: longhorn/longhorn/.github/workflows/stale.yaml@eb3790253449e3577b4acb88b5620258cde6d747 # v1.11.1
+    uses: longhorn/longhorn/.github/workflows/stale.yaml@efbad602f33c24a747185575eab29d2189390acd # v1.11.1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   call-workflow:
-    uses: longhorn/longhorn/.github/workflows/stale.yaml@efbad602f33c24a747185575eab29d2189390acd # v1.11.1
+    uses: longhorn/longhorn/.github/workflows/stale.yaml@efbad602f33c24a747185575eab29d2189390acd


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue [longhorn/longhorn#12920](https://github.com/longhorn/longhorn/issues/12920)

#### What this PR does / why we need it:
This PR updates the reusable stale workflow reference in longhorn-engine to the latest commit SHA from longhorn/longhorn master.
#### Special notes for your reviewer:
Only .github/workflows/stale.yaml is updated.
#### Additional documentation or context
