### PR TITLE
fix: reset file sync progress on retry to prevent exceeding 100%

### DIFF
--- a/pkg/sync/rpc/progress_tracker_test.go
+++ b/pkg/sync/rpc/progress_tracker_test.go
@@ -1,0 +1,122 @@
+package rpc
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// mockSyncOps records cumulative progress updates to simulate RebuildStatus.
+type mockSyncOps struct {
+	processedSize int64
+	totalSize     int64
+}
+
+func (m *mockSyncOps) UpdateSyncFileProgress(size int64) {
+	m.processedSize += size
+}
+
+func (m *mockSyncOps) progress() int {
+	if m.totalSize == 0 {
+		return 0
+	}
+	return int((float32(m.processedSize) / float32(m.totalSize)) * 100)
+}
+
+// TestProgressExceeds100WithoutTracker demonstrates the bug: when a file sync
+// is retried without resetting progress, the reported progress exceeds 100%.
+func (s *TestSuite) TestProgressExceeds100WithoutTracker(c *C) {
+	mock := &mockSyncOps{totalSize: 1000}
+
+	// Simulate syncing a single 1000-byte file directly (old code path).
+	// First attempt syncs 600 bytes, then fails.
+	mock.UpdateSyncFileProgress(600)
+	c.Assert(mock.progress(), Equals, 60)
+
+	// Retry: the file is synced from scratch, sending another 1000 bytes.
+	// Without any reset, processedSize becomes 1600 -> 160%.
+	mock.UpdateSyncFileProgress(1000)
+	c.Assert(mock.progress() > 100, Equals, true) // BUG: 160%
+}
+
+// TestProgressStaysCorrectWithTracker demonstrates the fix: perFileProgressOps
+// detaches on retry and a new tracker is created so progress never exceeds 100%.
+func (s *TestSuite) TestProgressStaysCorrectWithTracker(c *C) {
+	mock := &mockSyncOps{totalSize: 1000}
+	tracker := &perFileProgressOps{SyncFileOperations: mock}
+
+	// First attempt: sync 600 bytes, then fail.
+	tracker.UpdateSyncFileProgress(600)
+	c.Assert(mock.progress(), Equals, 60)
+
+	// Retry: detach subtracts the 600 bytes and disconnects the old tracker.
+	tracker.detach()
+	c.Assert(mock.progress(), Equals, 0)
+	c.Assert(mock.processedSize, Equals, int64(0))
+
+	// Create a new tracker for the retry (as the production code does).
+	tracker = &perFileProgressOps{SyncFileOperations: mock}
+
+	// Second attempt: full 1000-byte sync succeeds.
+	tracker.UpdateSyncFileProgress(1000)
+	c.Assert(mock.progress(), Equals, 100)
+}
+
+// TestProgressMultipleFilesWithRetry simulates a realistic scenario with
+// multiple files where one file needs a retry.
+func (s *TestSuite) TestProgressMultipleFilesWithRetry(c *C) {
+	// Total: fileA=400 + fileB=600 = 1000
+	mock := &mockSyncOps{processedSize: 1, totalSize: 1001} // mirrors PrepareRebuild init
+
+	trackerA := &perFileProgressOps{SyncFileOperations: mock}
+	trackerB := &perFileProgressOps{SyncFileOperations: mock}
+
+	// fileA syncs completely (400 bytes).
+	trackerA.UpdateSyncFileProgress(400)
+	c.Assert(mock.progress(), Equals, 40)
+
+	// fileB partially syncs 300 bytes, then fails.
+	trackerB.UpdateSyncFileProgress(300)
+	c.Assert(mock.progress(), Equals, 70)
+
+	// fileB retry: detach its contribution and create a new tracker.
+	trackerB.detach()
+	c.Assert(mock.progress(), Equals, 40)
+
+	trackerB = &perFileProgressOps{SyncFileOperations: mock}
+
+	// fileB syncs completely on second attempt (600 bytes).
+	trackerB.UpdateSyncFileProgress(600)
+	c.Assert(mock.progress(), Equals, 100)
+}
+
+// TestDetachIgnoresLateCallbacks verifies that after detach(), further
+// UpdateSyncFileProgress calls on the old tracker are ignored.
+func (s *TestSuite) TestDetachIgnoresLateCallbacks(c *C) {
+	mock := &mockSyncOps{totalSize: 1000}
+	tracker := &perFileProgressOps{SyncFileOperations: mock}
+
+	tracker.UpdateSyncFileProgress(500)
+	c.Assert(mock.processedSize, Equals, int64(500))
+
+	tracker.detach()
+	c.Assert(mock.processedSize, Equals, int64(0))
+
+	// Late callback from previous ssync attempt — should be ignored.
+	tracker.UpdateSyncFileProgress(200)
+	c.Assert(mock.processedSize, Equals, int64(0))
+}
+
+// TestDetachIdempotent verifies that calling detach() twice does not double-subtract.
+func (s *TestSuite) TestDetachIdempotent(c *C) {
+	mock := &mockSyncOps{totalSize: 1000}
+	tracker := &perFileProgressOps{SyncFileOperations: mock}
+
+	tracker.UpdateSyncFileProgress(500)
+	c.Assert(mock.processedSize, Equals, int64(500))
+
+	tracker.detach()
+	c.Assert(mock.processedSize, Equals, int64(0))
+
+	// Second detach should be a no-op.
+	tracker.detach()
+	c.Assert(mock.processedSize, Equals, int64(0))
+}

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -580,7 +580,19 @@ func (s *SyncAgentServer) fileSyncRemote(ctx context.Context, req *enginerpc.Fil
 
 	logrus.Infof("Replica %s starts to sync files %+v to from remote replicas %+v", req.ToHost, fileList, fromClientMap)
 
-	var ops sparserest.SyncFileOperations
+	// Create a per-file progress tracker for each non-empty file. The tracker forwards
+	// UpdateSyncFileProgress calls to RebuildStatus but also remembers how much it has
+	// contributed. On retry a new tracker is created and the old one is detached so that
+	// late callbacks from the previous ssync attempt cannot contaminate the new attempt.
+	fileProgressTrackers := make(map[string]*perFileProgressOps, len(req.SyncFileInfoList))
+	for _, info := range req.SyncFileInfoList {
+		if info.ActualSize > 0 {
+			fileProgressTrackers[info.ToFileName] = &perFileProgressOps{
+				SyncFileOperations: s.RebuildStatus,
+			}
+		}
+	}
+
 	fileStub := &sparserest.SyncFileStub{}
 
 	syncFileLock := &sync.Mutex{}
@@ -621,6 +633,11 @@ func (s *SyncAgentServer) fileSyncRemote(ctx context.Context, req *enginerpc.Fil
 							break
 						}
 						done = len(unsyncedFileMap) == 0
+						// Do not count size for disk meta file or empty disk file.
+						var fileOps sparserest.SyncFileOperations = fileStub
+						if syncFileInfo != nil && syncFileInfo.ActualSize != 0 {
+							fileOps = fileProgressTrackers[syncFileInfo.ToFileName]
+						}
 						syncFileLock.Unlock()
 
 						if syncFileInfo == nil {
@@ -642,18 +659,20 @@ func (s *SyncAgentServer) fileSyncRemote(ctx context.Context, req *enginerpc.Fil
 							} else {
 								logrus.WithError(err).Warnf("Replica %s failed to sync file %v from remote replica %v for %d times, will requeue the file and let other remote replicas handle it", req.ToHost, syncFileInfo.ToFileName, fromAddress, unsyncedFileRetryMap[syncFileInfo.ToFileName])
 								fileRetryBackoff.Next(syncFileInfo.ToFileName, time.Now())
+								if tracker, ok := fileProgressTrackers[syncFileInfo.ToFileName]; ok {
+									// Detach the old tracker so late UpdateSyncFileProgress callbacks
+									// from the previous ssync attempt do not contaminate the new one,
+									// then create a fresh tracker for the retry.
+									tracker.detach()
+									fileProgressTrackers[syncFileInfo.ToFileName] = &perFileProgressOps{
+										SyncFileOperations: s.RebuildStatus,
+									}
+								}
 							}
 							syncFileLock.Unlock()
 						}()
 
-						// Do not count size for disk meta file or empty disk file.
-						if syncFileInfo.ActualSize == 0 {
-							ops = fileStub
-						} else {
-							ops = s.RebuildStatus
-						}
-
-						port, err := s.launchReceiver("FilesSync", syncFileInfo.ToFileName, ops)
+						port, err := s.launchReceiver("FilesSync", syncFileInfo.ToFileName, fileOps)
 						if err != nil {
 							err = errors.Wrapf(err, "replica %s failed to launch receiver for file %s from remote replica %s", req.ToHost, syncFileInfo.ToFileName, fromAddress)
 							return false
@@ -684,6 +703,41 @@ func (s *SyncAgentServer) fileSyncRemote(ctx context.Context, req *enginerpc.Fil
 	logrus.Infof("Replica %s finished to sync files %+v to from remote replicas %+v", req.ToHost, fileList, fromClientMap)
 
 	return nil
+}
+
+// perFileProgressOps wraps SyncFileOperations to track how much progress a single file
+// has contributed to the global RebuildStatus. On retry, detach() subtracts the previous
+// contribution and disconnects the tracker so late callbacks from the previous ssync
+// attempt cannot contaminate the new attempt. A fresh tracker is then created for the retry.
+type perFileProgressOps struct {
+	sparserest.SyncFileOperations
+	mu          sync.Mutex
+	contributed int64
+	detached    bool
+}
+
+func (p *perFileProgressOps) UpdateSyncFileProgress(size int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.detached {
+		return
+	}
+	p.contributed += size
+	p.SyncFileOperations.UpdateSyncFileProgress(size)
+}
+
+// detach subtracts this file's accumulated progress from the underlying counter and
+// marks the tracker as detached so any further UpdateSyncFileProgress calls are ignored.
+func (p *perFileProgressOps) detach() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.contributed > 0 {
+		p.SyncFileOperations.UpdateSyncFileProgress(-p.contributed)
+		p.contributed = 0
+	}
+	p.detached = true
 }
 
 func (s *SyncAgentServer) PrepareRebuild(list []*enginerpc.SyncFileInfo, fromReplicaAddressMap map[string]bool) error {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#12949                                            

#### What this PR does / why we need it:                                 
                                                                         
When a file sync fails and is retried on an unstable network, the progress bytes were added again without subtracting the previous
attempt's contribution, causing rebuild progress to exceed 100%.
                                                                         
This PR wraps `SyncFileOperations` with a per-file tracker (`perFileProgressOps`) that remembers how much each file has             
contributed to the global progress. On retry, `reset()` subtracts the previous contribution before re-syncing, keeping the progress        
counter accurate and never exceeding 100%.    
                                                                         
#### Special notes for your reviewer:

- The fix is contained in `pkg/sync/rpc/server.go`                       
- Unit tests in `pkg/sync/rpc/progress_tracker_test.go` demonstrate:
  - The bug (progress exceeding 100% without the tracker)                
  - The fix (progress staying correct with the tracker)                  
  - Multi-file retry scenario                                            
  - Idempotent reset behavior                                            

#### Additional documentation or context                                 
The root cause is in `fileSyncRemote()`: on retry, the sparse sync compares checksums and transfers differing blocks again, but                  
`RebuildStatus.processedSize` is never decremented for the previous attempt's progress. This causes the same blocks to be counted multiple times. The `perFileProgressOps` wrapper intercepts `UpdateSyncFileProgress` calls, tracks per-file contributions, and subtracts them on `reset()` which is called in the existing retry path.                                                                         
                                                                              
