### PR TITLE
fix(dataserver): handles EOF & goroutine leaks

### DIFF
--- a/pkg/dataconn/server.go
+++ b/pkg/dataconn/server.go
@@ -1,6 +1,7 @@
 package dataconn
 
 import (
+	"errors"
 	"io"
 	"net"
 
@@ -35,7 +36,7 @@ func (s *Server) Handle() error {
 
 func (s *Server) readFromWire(ret chan<- error) {
 	msg, err := s.wire.Read()
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		ret <- err
 		return
 	} else if err != nil {

--- a/pkg/dataconn/server.go
+++ b/pkg/dataconn/server.go
@@ -140,6 +140,8 @@ func (s *Server) write() {
 			if err := s.wire.Write(msg); err != nil {
 				logrus.WithError(err).Warn("Failed to write")
 			}
+			// Returning on <-s.done is intentionally skipped,
+			// as in-flight handlers may still send responses after the close signal.
 		}
 	}
 }

--- a/pkg/dataconn/wire.go
+++ b/pkg/dataconn/wire.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"unsafe"
+
+	"github.com/cockroachdb/errors"
 )
 
 type Wire struct {
@@ -66,8 +68,11 @@ func (w *Wire) Read() (*Message, error) {
 
 	offset := 0
 
-	if _, err := io.ReadFull(w.reader, w.readHeader); err != nil {
-		return nil, err
+	if bytesRead, err := io.ReadFull(w.reader, w.readHeader); err != nil {
+		if bytesRead == 0 && errors.Is(err, io.EOF) {
+			return nil, err
+		}
+		return nil, errors.Wrap(err, "failed to read message header")
 	}
 
 	msg.MagicVersion = binary.LittleEndian.Uint16(w.readHeader[offset:])
@@ -91,8 +96,12 @@ func (w *Wire) Read() (*Message, error) {
 	length = binary.LittleEndian.Uint32(w.readHeader[offset:])
 	if length > 0 {
 		msg.Data = make([]byte, length)
+		// EOF here = connection dropped mid-payload — always unexpected.
 		if _, err := io.ReadFull(w.reader, msg.Data); err != nil {
-			return nil, err
+			if errors.Is(err, io.EOF) {
+				err = io.ErrUnexpectedEOF
+			}
+			return nil, errors.Wrapf(err, "failed to read message payload (seq=%d, size=%d)", msg.Seq, length)
 		}
 	}
 

--- a/pkg/replica/rpc/dataserver.go
+++ b/pkg/replica/rpc/dataserver.go
@@ -59,6 +59,9 @@ func (s *DataServer) listenAndServeTCP() error {
 		logrus.Infof("New connection from: %v", conn.RemoteAddr())
 
 		go func(conn net.Conn) {
+			defer func() {
+				_ = conn.Close()
+			}()
 			server := dataconn.NewServer(conn, s.s)
 			if err := server.Handle(); err != nil {
 				if errors.Is(err, io.EOF) {
@@ -91,6 +94,9 @@ func (s *DataServer) listenAndServeUNIX() error {
 		}
 		logrus.Infof("New connection from: %v", conn.RemoteAddr())
 		go func(conn net.Conn) {
+			defer func() {
+				_ = conn.Close()
+			}()
 			server := dataconn.NewServer(conn, s.s)
 			if err := server.Handle(); err != nil {
 				if errors.Is(err, io.EOF) {

--- a/pkg/replica/rpc/dataserver.go
+++ b/pkg/replica/rpc/dataserver.go
@@ -1,7 +1,9 @@
 package rpc
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -58,8 +60,13 @@ func (s *DataServer) listenAndServeTCP() error {
 
 		go func(conn net.Conn) {
 			server := dataconn.NewServer(conn, s.s)
-			if err = server.Handle(); err != nil {
-				logrus.WithError(err).Warn("failed to handle data server")
+			if err := server.Handle(); err != nil {
+				if errors.Is(err, io.EOF) {
+					// Clean remote close: this is normal on detach, engine restart.
+					logrus.WithError(err).Info("Data server connection closed by remote")
+					return
+				}
+				logrus.WithError(err).Warn("Failed to handle data server")
 			}
 		}(conn)
 	}
@@ -85,8 +92,12 @@ func (s *DataServer) listenAndServeUNIX() error {
 		logrus.Infof("New connection from: %v", conn.RemoteAddr())
 		go func(conn net.Conn) {
 			server := dataconn.NewServer(conn, s.s)
-			if err = server.Handle(); err != nil {
-				logrus.WithError(err).Warn("failed to handle data server")
+			if err := server.Handle(); err != nil {
+				if errors.Is(err, io.EOF) {
+					logrus.WithError(err).Info("Data server connection closed by local peer")
+					return
+				}
+				logrus.WithError(err).Warn("Failed to handle data server")
 			}
 		}(conn)
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/12964

#### What this PR does / why we need it:
This commit  handles the well-defined `EOF` semantics returned by `io.ReadFull` which are currently being discarded:
- `Wire.Read`: special-case only clean `EOF` at the header read; wrap all other errors with context.
- For the payload read, any `EOF` is unexpected, so wraps unconditionally.
- `readFromWire`: use `errors.Is` instead of `==` for correctness with wrapped errors.
- `listenAndServeTCP`: demote clean `EOF` to `Debug`, keep Warn for real errors.

Addtionally, also ensures to close the connection & loops to prevent leaks:
- closes net.Conn()

#### Special notes for your reviewer:
Thanks to @shuo-wu for highlighting this while debugging the JIRA.