### PR TITLE
fix: propagate gRPC context to FileSend for proper cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/longhorn/backupstore v0.0.0-20260329081928-dd6c86c9ba6d
 	github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8
 	github.com/longhorn/go-iscsi-helper v0.0.0-20260327125832-d1a62805e28f
-	github.com/longhorn/sparse-tools v0.0.0-20260411033103-ab9b450f4535
+	github.com/longhorn/sparse-tools v0.0.0-20260423054056-0a1d90de7298
 	github.com/longhorn/types v0.0.0-20260327130848-66f6de8a2fb3
 	github.com/moby/moby v26.1.5+incompatible
 	github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8 h1:HxGyRXT
 github.com/longhorn/go-common-libs v0.0.0-20260328134226-cafa38fc4ce8/go.mod h1:Vw9cRchaffWmZMjHOjqhSG37tFN9DdQ/isKs4ViPXQE=
 github.com/longhorn/go-iscsi-helper v0.0.0-20260327125832-d1a62805e28f h1:z7BVxbEJAgyTMEfpOvkTa2VAXF69emkp7BU+y3ncwd4=
 github.com/longhorn/go-iscsi-helper v0.0.0-20260327125832-d1a62805e28f/go.mod h1:2uLvPs5+Ka1PLhV9Aoa+WbZ6FzOA39t1rolvuSdHaQg=
-github.com/longhorn/sparse-tools v0.0.0-20260411033103-ab9b450f4535 h1:7s0hNMxJE0BPvS44isjk8q7wIjsXJ7+hmz+mpkDQtDk=
-github.com/longhorn/sparse-tools v0.0.0-20260411033103-ab9b450f4535/go.mod h1:d8l9nyC8No3PIfYHwZunnBj88y5M4sDM+h6uZyTtaNk=
+github.com/longhorn/sparse-tools v0.0.0-20260423054056-0a1d90de7298 h1:sz4r9XoWP+ONK81K2/ml95YjmagAeJjsJ7neZjI+L88=
+github.com/longhorn/sparse-tools v0.0.0-20260423054056-0a1d90de7298/go.mod h1:d8l9nyC8No3PIfYHwZunnBj88y5M4sDM+h6uZyTtaNk=
 github.com/longhorn/types v0.0.0-20260327130848-66f6de8a2fb3 h1:g7+NsK5z7MkySxzSS5HpwXogiMefQdWkfbCmx5/TCaw=
 github.com/longhorn/types v0.0.0-20260327130848-66f6de8a2fb3/go.mod h1:JjRATl5N8MzlvUIDSFKOlsINg484dne7Y0c/r2x9i0I=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/pkg/sync/rpc/server.go
+++ b/pkg/sync/rpc/server.go
@@ -356,7 +356,7 @@ func (s *SyncAgentServer) FileSend(ctx context.Context, req *enginerpc.FileSendR
 	directIO := filepath.Ext(strings.TrimSpace(req.FromFileName)) != ".meta"
 
 	logrus.Infof("Syncing file %v to %v", req.FromFileName, address)
-	if err := sparse.SyncFile(req.FromFileName, address, int(req.FileSyncHttpClientTimeout), directIO, req.FastSync); err != nil {
+	if err := sparse.SyncFileWithContext(ctx, req.FromFileName, address, int(req.FileSyncHttpClientTimeout), directIO, req.FastSync); err != nil {
 		return nil, err
 	}
 	logrus.Infof("Done syncing file %v to %v", req.FromFileName, address)

--- a/vendor/github.com/longhorn/sparse-tools/sparse/client.go
+++ b/vendor/github.com/longhorn/sparse-tools/sparse/client.go
@@ -122,6 +122,11 @@ func newSyncClient(remote string, sourceName string, size int64, rw ReaderWriter
 
 // SyncFile synchronizes local file to remote host
 func SyncFile(localPath string, remote string, httpClientTimeout int, directIO, fastSync bool) error {
+	return SyncFileWithContext(context.Background(), localPath, remote, httpClientTimeout, directIO, fastSync)
+}
+
+// SyncFileWithContext synchronizes local file to remote host until the context is canceled.
+func SyncFileWithContext(ctx context.Context, localPath string, remote string, httpClientTimeout int, directIO, fastSync bool) error {
 	fileInfo, err := os.Stat(localPath)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get file info of source file %s", localPath)
@@ -144,7 +149,7 @@ func SyncFile(localPath string, remote string, httpClientTimeout int, directIO, 
 		_ = fileIo.Close()
 	}()
 
-	return SyncContent(fileIo.Name(), fileIo, fileSize, remote, httpClientTimeout, directIO, fastSync)
+	return SyncContentWithContext(ctx, fileIo.Name(), fileIo, fileSize, remote, httpClientTimeout, directIO, fastSync)
 }
 
 func newFileIoProcessor(localPath string, directIO bool) (FileIoProcessor, error) {
@@ -155,6 +160,10 @@ func newFileIoProcessor(localPath string, directIO bool) (FileIoProcessor, error
 }
 
 func SyncContent(sourceName string, rw ReaderWriterAt, fileSize int64, remote string, httpClientTimeout int, directIO, fastSync bool) (err error) {
+	return SyncContentWithContext(context.Background(), sourceName, rw, fileSize, remote, httpClientTimeout, directIO, fastSync)
+}
+
+func SyncContentWithContext(ctx context.Context, sourceName string, rw ReaderWriterAt, fileSize int64, remote string, httpClientTimeout int, directIO, fastSync bool) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "failed to sync content for source file %v", sourceName)
 	}()
@@ -181,8 +190,8 @@ func SyncContent(sourceName string, rw ReaderWriterAt, fileSize int64, remote st
 	client := newSyncClient(remote, sourceName, fileSize, rw, directIO, httpClientTimeout,
 		recordedChangeTime, recordedChecksumMethod, recordedChecksum, syncBatchSize, numSyncWorkers)
 
-	// Set context early so that fast-sync check is also cancellable on function return
-	ctx, cancel := context.WithCancel(context.Background())
+	// Derive a cancellable context so best-effort cleanup can stop in-flight requests.
+	ctx, cancel := context.WithCancel(ctx)
 	client.ctx = ctx
 	defer cancel()
 	defer client.close() // kill the server no matter success or not, best effort

--- a/vendor/github.com/longhorn/sparse-tools/sparse/rest/server.go
+++ b/vendor/github.com/longhorn/sparse-tools/sparse/rest/server.go
@@ -76,6 +76,10 @@ type SyncServer struct {
 }
 
 func Server(ctx context.Context, port string, filePath string, syncFileOps SyncFileOperations) error {
+	return serverWithIdleTimeout(ctx, port, filePath, syncFileOps, defaultIdleTimeout)
+}
+
+func serverWithIdleTimeout(ctx context.Context, port string, filePath string, syncFileOps SyncFileOperations, idleTimeout time.Duration) error {
 	log.Infof("Creating Ssync service")
 	ctx, cancelFunc := context.WithCancel(ctx)
 	srv := &http.Server{
@@ -84,7 +88,7 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	}
 
 	// if server has no connection for a period of time, it will shutdown itself to prevent receiver from getting stuck.
-	idleTimer := NewIdleTimer(defaultIdleTimeout)
+	idleTimer := NewIdleTimer(idleTimeout)
 	srv.ConnState = idleTimer.ConnState
 
 	fileAlreadyExists := true
@@ -118,5 +122,5 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 
 // TestServer daemon serves only one connection for each test then exits
 func TestServer(ctx context.Context, port string, filePath string, timeout int) error {
-	return Server(ctx, port, filePath, &SyncFileStub{})
+	return serverWithIdleTimeout(ctx, port, filePath, &SyncFileStub{}, time.Duration(timeout)*time.Second)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -331,7 +331,7 @@ github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev
 github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
-# github.com/longhorn/sparse-tools v0.0.0-20260411033103-ab9b450f4535
+# github.com/longhorn/sparse-tools v0.0.0-20260423054056-0a1d90de7298
 ## explicit; go 1.24.0
 github.com/longhorn/sparse-tools/cli/ssync
 github.com/longhorn/sparse-tools/sparse


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#12949

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
