### PR TITLE
fix(client): prevent NPE in GetControllerReplicaInfo

### DIFF
--- a/pkg/controller/client/controller_client.go
+++ b/pkg/controller/client/controller_client.go
@@ -96,11 +96,18 @@ func GetVolumeInfo(v *enginerpc.Volume) *types.VolumeInfo {
 	}
 }
 
-func GetControllerReplicaInfo(cr *enginerpc.ControllerReplica) *types.ControllerReplicaInfo {
+func GetControllerReplicaInfo(cr *enginerpc.ControllerReplica) (*types.ControllerReplicaInfo, error) {
+	if cr == nil {
+		return nil, errors.New("controller returned an empty replica response")
+	}
+	if cr.Address == nil {
+		return nil, errors.New("controller returned a replica response without an address")
+	}
+
 	return &types.ControllerReplicaInfo{
 		Address: cr.Address.Address,
 		Mode:    types.Mode(cr.Mode.String()),
-	}
+	}, nil
 }
 
 func GetControllerReplica(r *types.ControllerReplicaInfo) *enginerpc.ControllerReplica {
@@ -282,7 +289,11 @@ func (c *ControllerClient) ReplicaList() ([]*types.ControllerReplicaInfo, error)
 
 	replicas := []*types.ControllerReplicaInfo{}
 	for _, cr := range reply.Replicas {
-		replicas = append(replicas, GetControllerReplicaInfo(cr))
+		replica, err := GetControllerReplicaInfo(cr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to decode a replica for volume %v", c.serviceURL)
+		}
+		replicas = append(replicas, replica)
 	}
 
 	return replicas, nil
@@ -300,7 +311,12 @@ func (c *ControllerClient) ReplicaGet(address string) (*types.ControllerReplicaI
 		return nil, errors.Wrapf(err, "failed to get replica %v for volume %v", address, c.serviceURL)
 	}
 
-	return GetControllerReplicaInfo(cr), nil
+	replica, err := GetControllerReplicaInfo(cr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode replica %v for volume %v", address, c.serviceURL)
+	}
+
+	return replica, nil
 }
 
 func (c *ControllerClient) ReplicaCreate(address string, snapshotRequired bool, mode types.Mode) (*types.ControllerReplicaInfo, error) {
@@ -317,7 +333,12 @@ func (c *ControllerClient) ReplicaCreate(address string, snapshotRequired bool, 
 		return nil, errors.Wrapf(err, "failed to create replica %v for volume %v", address, c.serviceURL)
 	}
 
-	return GetControllerReplicaInfo(cr), nil
+	replica, err := GetControllerReplicaInfo(cr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode created replica %v for volume %v", address, c.serviceURL)
+	}
+
+	return replica, nil
 }
 
 func (c *ControllerClient) ReplicaDelete(address string) error {
@@ -347,7 +368,12 @@ func (c *ControllerClient) ReplicaUpdate(address string, mode types.Mode) (*type
 		return nil, errors.Wrapf(err, "failed to update replica %v for volume %v", address, c.serviceURL)
 	}
 
-	return GetControllerReplicaInfo(cr), nil
+	replica, err := GetControllerReplicaInfo(cr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode updated replica %v for volume %v", address, c.serviceURL)
+	}
+
+	return replica, nil
 }
 
 func (c *ControllerClient) ReplicaPrepareRebuild(address, instanceName string) ([]types.SyncFileInfo, error) {

--- a/pkg/controller/client/controller_client_test.go
+++ b/pkg/controller/client/controller_client_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+
+	"github.com/longhorn/types/pkg/generated/enginerpc"
+
+	"github.com/longhorn/longhorn-engine/pkg/types"
+)
+
+type fakeClientConn struct{}
+
+func (f *fakeClientConn) Invoke(_ context.Context, method string, _, reply any, _ ...grpc.CallOption) error {
+	if method != enginerpc.ControllerService_ControllerReplicaCreate_FullMethodName {
+		return errors.New("unexpected grpc method: " + method)
+	}
+
+	controllerReplica, ok := reply.(*enginerpc.ControllerReplica)
+	if !ok {
+		return errors.New("unexpected reply type")
+	}
+
+	// Simulate the malformed success response seen during rebuild storms:
+	// the RPC succeeds, but the replica payload omits its address.
+	*controllerReplica = enginerpc.ControllerReplica{}
+	return nil
+}
+
+func (f *fakeClientConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, errors.New("streaming is not implemented in fakeClientConn")
+}
+
+func TestGetControllerReplicaInfoRejectsMalformedResponses(t *testing.T) {
+	testCases := map[string]*enginerpc.ControllerReplica{
+		"nil replica":     nil,
+		"missing address": {},
+	}
+
+	for name, replica := range testCases {
+		t.Run(name, func(t *testing.T) {
+			info, err := GetControllerReplicaInfo(replica)
+			if err == nil {
+				t.Fatalf("GetControllerReplicaInfo() returned nil error, got info=%v", info)
+			}
+			if info != nil {
+				t.Fatalf("GetControllerReplicaInfo() returned info=%v, want nil", info)
+			}
+		})
+	}
+}
+
+func TestReplicaCreateRejectsMalformedReplicaResponse(t *testing.T) {
+	controllerClient := &ControllerClient{
+		serviceURL: "tcp://engine.example",
+		ControllerServiceContext: ControllerServiceContext{
+			service: enginerpc.NewControllerServiceClient(&fakeClientConn{}),
+		},
+	}
+
+	replica, err := controllerClient.ReplicaCreate("tcp://replica.example", true, types.WO)
+	if err == nil {
+		t.Fatalf("ReplicaCreate() returned nil error, got replica=%v", replica)
+	}
+	if replica != nil {
+		t.Fatalf("ReplicaCreate() returned replica=%v, want nil", replica)
+	}
+	if !strings.Contains(err.Error(), "failed to decode created replica") {
+		t.Fatalf("ReplicaCreate() error = %q, want it to mention decode failure", err)
+	}
+}


### PR DESCRIPTION




#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13087

#### What this PR does / why we need it:

During replica rebuild storms, the gRPC ControllerReplicaCreate call may succeed but return a ControllerReplica response with a nil Address field. Accessing cr.Address.Address without a nil check causes a SIGSEGV panic, crashing the instance-manager process and triggering cascading volume detachments.

Change GetControllerReplicaInfo to return an error when the response is nil or missing its Address field, and update all call sites (ReplicaList, ReplicaGet, ReplicaCreate, ReplicaUpdate) to propagate the error instead of panicking.

#### Special notes for your reviewer:

#### Additional documentation or context
