### PR TITLE
fix: return error when ControllerServer cannot find a replica based on the address

### DIFF
--- a/pkg/controller/control.go
+++ b/pkg/controller/control.go
@@ -524,7 +524,12 @@ func (c *Controller) RemoveReplica(address string) error {
 }
 
 func (c *Controller) ListReplicas() []types.Replica {
-	return c.replicas
+	c.RLock()
+	defer c.RUnlock()
+
+	replicas := make([]types.Replica, len(c.replicas))
+	copy(replicas, c.replicas)
+	return replicas
 }
 
 func (c *Controller) SetReplicaMode(address string, mode types.Mode) error {

--- a/pkg/controller/rpc/server.go
+++ b/pkg/controller/rpc/server.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -101,14 +103,14 @@ func (cs *ControllerServer) getVolume() *enginerpc.Volume {
 	}
 }
 
-func (cs *ControllerServer) getControllerReplica(address string) *enginerpc.ControllerReplica {
+func (cs *ControllerServer) getControllerReplica(address string) (*enginerpc.ControllerReplica, error) {
 	for _, r := range cs.c.ListReplicas() {
 		if r.Address == address {
-			return cs.replicaToControllerReplica(&r)
+			return cs.replicaToControllerReplica(&r), nil
 		}
 	}
 
-	return nil
+	return nil, status.Errorf(codes.NotFound, "cannot find the replica with address %s in the controller server of volume %s", address, cs.c.VolumeName)
 }
 
 func (cs *ControllerServer) listControllerReplica() []*enginerpc.ControllerReplica {
@@ -211,7 +213,7 @@ func (cs *ControllerServer) ReplicaList(ctx context.Context, req *emptypb.Empty)
 }
 
 func (cs *ControllerServer) ReplicaGet(ctx context.Context, req *enginerpc.ReplicaAddress) (*enginerpc.ControllerReplica, error) {
-	return cs.getControllerReplica(req.Address), nil
+	return cs.getControllerReplica(req.Address)
 }
 
 func (cs *ControllerServer) ControllerReplicaCreate(ctx context.Context, req *enginerpc.ControllerReplicaCreateRequest) (*enginerpc.ControllerReplica, error) {
@@ -219,7 +221,7 @@ func (cs *ControllerServer) ControllerReplicaCreate(ctx context.Context, req *en
 		return nil, err
 	}
 
-	return cs.getControllerReplica(req.Address), nil
+	return cs.getControllerReplica(req.Address)
 }
 
 func (cs *ControllerServer) ReplicaDelete(ctx context.Context, req *enginerpc.ReplicaAddress) (*emptypb.Empty, error) {
@@ -235,7 +237,7 @@ func (cs *ControllerServer) ReplicaUpdate(ctx context.Context, req *enginerpc.Co
 		return nil, err
 	}
 
-	return cs.getControllerReplica(req.Address.Address), nil
+	return cs.getControllerReplica(req.Address.Address)
 }
 
 func (cs *ControllerServer) ReplicaPrepareRebuild(ctx context.Context, req *enginerpc.ReplicaAddress) (*enginerpc.ReplicaPrepareRebuildReply, error) {
@@ -244,8 +246,13 @@ func (cs *ControllerServer) ReplicaPrepareRebuild(ctx context.Context, req *engi
 		return nil, err
 	}
 
+	r, err := cs.getControllerReplica(req.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	return &enginerpc.ReplicaPrepareRebuildReply{
-		Replica:          cs.getControllerReplica(req.Address),
+		Replica:          r,
 		SyncFileInfoList: cs.syncFileInfoListToControllerFormat(list),
 	}, nil
 }
@@ -255,7 +262,7 @@ func (cs *ControllerServer) ReplicaVerifyRebuild(ctx context.Context, req *engin
 		return nil, err
 	}
 
-	return cs.getControllerReplica(req.Address), nil
+	return cs.getControllerReplica(req.Address)
 }
 
 func (cs *ControllerServer) ReplicaRebuildConcurrentSyncLimitSet(ctx context.Context, req *enginerpc.ReplicaRebuildConcurrentSyncLimitSetRequest) (*emptypb.Empty, error) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13087

#### What this PR does / why we need it:

Otherwise, this `ContollerServer` gRPC server will marshal the response as a nil `*ControllerReplica` pointer. Then, the client side will unmarshals the empty-byte result into a **zero-value** struct `cr *enginerpc.ControllerReplica`. This `cr` itself is non-nil but all its pointer fields like `cr.Address` are nil. Finally, it leads to some NPE issues when the callers of the client try to use `cr`

#### Special notes for your reviewer:

#### Additional documentation or context
