### PR TITLE
fix: make engine runtime paths follow LONGHORN_DATA_PATH

### DIFF
--- a/pkg/replica/hash.go
+++ b/pkg/replica/hash.go
@@ -24,6 +24,7 @@ import (
 	xattrType "github.com/longhorn/sparse-tools/types"
 
 	"github.com/longhorn/longhorn-engine/pkg/types"
+	"github.com/longhorn/longhorn-engine/pkg/util"
 
 	diskutil "github.com/longhorn/longhorn-engine/pkg/util/disk"
 )
@@ -31,10 +32,13 @@ import (
 const (
 	defaultHashMethod = "crc64"
 
-	FileLockDirectory = "/host/var/lib/longhorn/.lock"
-	HashLockFileName  = "hash"
+	HashLockFileName = "hash"
 
 	checkInterval = 10 * 1024 * 1024
+)
+
+var (
+	FileLockDirectory = util.GetFileLockDirectory()
 )
 
 type SnapshotHashStatus struct {

--- a/pkg/util/fsfreeze.go
+++ b/pkg/util/fsfreeze.go
@@ -19,7 +19,6 @@ import (
 const (
 	binaryFsfreeze          = "fsfreeze"
 	notFrozenErrorSubstring = "Invalid argument"
-	freezePointDirectory    = "/var/lib/longhorn/freeze" // We expect this to be INSIDE the container namespace.
 	DevicePathPrefix        = longhorndev.DevPath
 
 	// If the block device is functioning and the filesystem is frozen, fsfreeze -u immediately returns successfully.
@@ -44,7 +43,7 @@ func GetFreezePointFromVolumeName(volumeName string) string {
 	if volumeName == "" {
 		return ""
 	}
-	return filepath.Join(freezePointDirectory, volumeName)
+	return filepath.Join(GetFreezePointDirectory(), volumeName)
 }
 
 // GetDevicePathFromVolumeName mirrors longhorndev.getDev. It returns the device path that go-iscsi-helper will use.

--- a/pkg/util/paths.go
+++ b/pkg/util/paths.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultLonghornDataPath = "/var/lib/longhorn"
+	LonghornDataPathEnv     = "LONGHORN_DATA_PATH"
+
+	hostMountPrefix = "/host"
+)
+
+var (
+	longhornDataPath     = normalizeLonghornDataPath(os.Getenv(LonghornDataPathEnv))
+	hostLonghornDataPath = filepath.Join(hostMountPrefix, strings.TrimPrefix(longhornDataPath, "/"))
+	freezePointDirectory = filepath.Join(longhornDataPath, "freeze")
+	fileLockDirectory    = filepath.Join(hostLonghornDataPath, ".lock")
+	unixDomainSocketDir  = filepath.Join(hostLonghornDataPath, "unix-domain-socket")
+)
+
+func normalizeLonghornDataPath(path string) string {
+	if path == "" {
+		path = DefaultLonghornDataPath
+	}
+
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		return DefaultLonghornDataPath
+	}
+
+	return cleaned
+}
+
+func GetLonghornDataPath() string {
+	return longhornDataPath
+}
+
+func GetHostLonghornDataPath() string {
+	return hostLonghornDataPath
+}
+
+func GetFreezePointDirectory() string {
+	return freezePointDirectory
+}
+
+func GetFileLockDirectory() string {
+	return fileLockDirectory
+}
+
+func GetUnixDomainSocketDirectoryInContainer() string {
+	return unixDomainSocketDir
+}

--- a/pkg/util/paths_test.go
+++ b/pkg/util/paths_test.go
@@ -1,0 +1,35 @@
+package util
+
+import "testing"
+
+func TestNormalizeLonghornDataPath(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"default when empty": {
+			input:    "",
+			expected: DefaultLonghornDataPath,
+		},
+		"clean absolute path": {
+			input:    "/data/longhorn/",
+			expected: "/data/longhorn",
+		},
+		"clean nested segments": {
+			input:    "/data/../data2/longhorn",
+			expected: "/data2/longhorn",
+		},
+		"reject relative path": {
+			input:    "data/longhorn",
+			expected: DefaultLonghornDataPath,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if actual := normalizeLonghornDataPath(tc.input); actual != tc.expected {
+				t.Fatalf("got %q, want %q", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,8 +25,6 @@ import (
 var (
 	MaximumVolumeNameSize = 64
 	validVolumeName       = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
-
-	unixDomainSocketDirectoryInContainer = "/host/var/lib/longhorn/unix-domain-socket/"
 )
 
 const (
@@ -277,7 +275,7 @@ func GetAddresses(volumeName, address string, dataServerProtocol types.DataServe
 		return ParseAddresses(address)
 	case types.DataServerProtocolUNIX:
 		controlAddress, _, syncAddress, syncPort, err := ParseAddresses(address)
-		sockPath := filepath.Join(unixDomainSocketDirectoryInContainer, volumeName+".sock")
+		sockPath := filepath.Join(GetUnixDomainSocketDirectoryInContainer(), volumeName+".sock")
 		return controlAddress, sockPath, syncAddress, syncPort, err
 	default:
 		return "", "", "", -1, fmt.Errorf("unsupported protocol: %v", dataServerProtocol)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/9083

#### What this PR does / why we need it:

This change makes longhorn-engine runtime helper paths configurable through `LONGHORN_DATA_PATH` instead of assuming `/var/lib/longhorn`.

Previously, engine-side paths such as unix domain sockets, freeze points, and snapshot hash lock files were still tied to `/var/lib/longhorn`. To support environments where Longhorn is installed with a different data root, longhorn-engine now derives these paths from the configured Longhorn data path while keeping `/var/lib/longhorn` as the default.

#### Special notes for your reviewer:

#### Additional documentation or context
