### PR TITLE
fix: preserve OS TCP keepalive settings for sync agent

### DIFF
--- a/app/cmd/sync_agent.go
+++ b/app/cmd/sync_agent.go
@@ -82,7 +82,11 @@ func startSyncAgent(c *cli.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	listen, err := net.Listen("tcp", listenPort)
+	// Preserve the OS keepalive timings. The listener enables keepalive on each
+	// accepted connection without letting the Go standard library replace them.
+	// https://github.com/grpc/grpc-go/issues/6250
+	listenConfig := net.ListenConfig{KeepAlive: -1}
+	listen, err := listenConfig.Listen(ctx, "tcp", listenPort)
 	if err != nil {
 		return errors.Wrap(err, "failed to listen")
 	}
@@ -91,7 +95,26 @@ func startSyncAgent(c *cli.Context) error {
 
 	logrus.Infof("Listening on sync %s", listenPort)
 
-	return server.Serve(listen)
+	return server.Serve(tcpKeepAliveListener{Listener: listen})
+}
+
+type tcpKeepAliveListener struct {
+	net.Listener
+}
+
+func (l tcpKeepAliveListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		if err := tcpConn.SetKeepAlive(true); err != nil {
+			logrus.WithError(err).Warnf("Failed to enable TCP keepalive on connection from %v; using connection without TCP keepalive", conn.RemoteAddr())
+		}
+	}
+
+	return conn, nil
 }
 
 func doReset(c *cli.Context) error {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

issue longhorn/longhorn#13703

#### What this PR does / why we need it:

Create the sync-agent listener without Go TCP keepalive timing overrides, then enable keepalive on each accepted connection. This prevents a single missed probe from canceling a long-running FileSend request and interrupting the replica rebuild.

#### Special notes for your reviewer:

I've created a companion test at https://github.com/longhorn/longhorn-tests/pull/3639.  I'm not sure the right way to run this test, but separately I built an engine image with the fix in this PR and re-ran my original reproduction on my own cluster and both reproduced the original failure and could not reproduce with this fix.  I also saw `ss` output confirming that the TCP keepalive timer was set to 120 minutes, which I guess is my OS default.