### PR TITLE
test(integration): fix flaky test_metrics timing race

### DIFF
--- a/integration/data/test_basic_ops.py
+++ b/integration/data/test_basic_ops.py
@@ -61,8 +61,10 @@ def test_metrics(grpc_replica1, grpc_replica2, grpc_controller):  # NOQA
     data = random_string(length)
     verify_data(rw_dev, offset, data)
 
-    # metrics update period is 1 second
-    max_iters = 10
+    # The reported metrics come from the last completed 1-second bucket, so a
+    # single IO burst is only visible for one ~1s window (up to ~2s after the
+    # IO). Poll long enough to span more than two metrics periods.
+    max_iters = 30
     for i in range(max_iters):
         try:
             metrics = grpc_controller.metrics_get()


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/13771

#### What this PR does / why we need it:

test_metrics issues a single IO burst and then polls metrics_get() for about one second. The controller reports metrics from the last completed 1-second bucket, so a single burst is only visible for one ~1s window that can end up to ~2s after the IO. The poll budget (10 iters x 0.1s) is the same magnitude as the metrics period, so when the IO lands early in a bucket the visible window opens after the poll budget is exhausted and the test reads 0, failing probabilistically on readThroughput.

Raise max_iters from 10 to 30 so the poll budget (~2.9s) spans more than two metrics periods and reliably captures the non-zero window. No product code change.

#### Special notes for your reviewer:

#### Additional documentation or context
