### PR TITLE
fix: include volume name in expansion snapshot name to avoid Snapshot CR collision

### DIFF
--- a/app/cmd/replica.go
+++ b/app/cmd/replica.go
@@ -130,7 +130,9 @@ func startReplica(c *cli.Context) (err error) {
 		}
 	}()
 
-	s := replica.NewServer(ctx, dir, backingFile, diskutil.ReplicaSectorSize, disableRevCounter, unmapMarkDiskChainRemoved, snapshotMaxCount, snapshotMaxSize, encrypted)
+	volumeName := c.GlobalString("volume-name")
+
+	s := replica.NewServer(ctx, dir, backingFile, diskutil.ReplicaSectorSize, disableRevCounter, unmapMarkDiskChainRemoved, snapshotMaxCount, snapshotMaxSize, encrypted, volumeName)
 
 	address := c.String("listen")
 
@@ -149,7 +151,6 @@ func startReplica(c *cli.Context) (err error) {
 		}
 	}
 
-	volumeName := c.GlobalString("volume-name")
 	replicaInstanceName := c.String("replica-instance-name")
 	dataServerProtocol := c.String("data-server-protocol")
 

--- a/integration/common/constants.py
+++ b/integration/common/constants.py
@@ -74,6 +74,9 @@ ENGINE_NAME_BASE = TEST_PREFIX + "instance-engine-"
 REPLICA_NAME_BASE = TEST_PREFIX + "instance-replica-"
 
 REPLICA_META_FILE_NAME = "volume.meta"
+# The expansion snapshot is named "expand-<size>-<volumeName>" so that replicas
+# of different volumes never collide. Integration test replicas are launched
+# without a volume name, so it falls back to the size-only form "expand-<size>".
 EXPANSION_DISK_TMP_META_NAME = \
     "volume-snap-expand-%d.img.meta.tmp" % EXPANDED_SIZE
 EXPANSION_DISK_NAME = "volume-snap-expand-%d.img" % EXPANDED_SIZE

--- a/integration/common/core.py
+++ b/integration/common/core.py
@@ -27,7 +27,7 @@ from common.constants import (
     RETRY_COUNTS_SHORT, RETRY_INTERVAL_SHORT,
     PROC_STATE_STARTING, PROC_STATE_RUNNING,
     PROC_STATE_ERROR,
-    ENGINE_NAME, EXPANDED_SIZE_STR,
+    ENGINE_NAME,
     VOLUME_NO_FRONTEND_NAME,
     FIXED_REPLICA_PATH1, FIXED_REPLICA_PATH2, REPLICA_NAME
 )
@@ -274,8 +274,13 @@ def get_dev_path(name):
     return os.path.join(LONGHORN_DEV_DIR, name)
 
 
-def get_expansion_snapshot_name():
-    return 'expand-{0}'.format(EXPANDED_SIZE_STR)
+def get_expansion_snapshot_name(grpc_replica_client):
+    # The expansion snapshot name includes the volume name suffix, so it depends
+    # on how the replica was launched. Discover it from the replica chain, where
+    # the expansion snapshot is the parent of the head (chain[1]).
+    chain = grpc_replica_client.replica_get().chain
+    disk_name = chain[1]
+    return disk_name[len('volume-snap-'):-len('.img')]
 
 
 def get_replica_paths_from_snapshot_name(snap_name):

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -938,7 +938,7 @@ def test_volume_expand_with_snapshots(  # NOQA
 
     # `expand` will create a snapshot then apply the new size
     # on the new head file
-    snap_expansion = get_expansion_snapshot_name()
+    snap_expansion = get_expansion_snapshot_name(grpc_replica_client)
     r1 = grpc_replica_client.replica_get()
     assert r1.chain[1] == 'volume-snap-{}.img'.format(snap_expansion)
     assert r1.size == EXPANDED_SIZE_STR
@@ -1107,6 +1107,50 @@ def test_expand_multiple_times():
 
         cleanup_process(em_client)
         cleanup_process(rm_client)
+
+
+def test_expansion_snapshot_name_includes_volume_name(
+        process_manager_client):  # NOQA
+    """
+    Regression test for the expansion Snapshot CR name collision
+    (longhorn/longhorn#13386).
+
+    The volume-expansion system snapshot used to be named "expand-<size>",
+    using only the target size. Because Snapshot CR names are unique within a
+    Longhorn namespace, two different volumes expanded to the same byte size
+    produced the same name and collided. The replica now derives the name from
+    its volume name, so replicas launched with different volume names must
+    produce different expansion snapshot names, while staying deterministic
+    per volume.
+    """
+    volume_name_1 = "test-expand-vol-1"
+    volume_name_2 = "test-expand-vol-2"
+
+    replica_process_1 = create_replica_process(
+        process_manager_client, REPLICA_NAME, volume_name=volume_name_1)
+    grpc_replica_client_1 = cleanup_replica(
+        ReplicaClient(get_process_address(replica_process_1)))
+
+    replica_process_2 = create_replica_process(
+        process_manager_client, REPLICA_2_NAME, volume_name=volume_name_2)
+    grpc_replica_client_2 = cleanup_replica(
+        ReplicaClient(get_process_address(replica_process_2)))
+
+    for grpc_replica_client in (grpc_replica_client_1, grpc_replica_client_2):
+        open_replica(grpc_replica_client)
+        grpc_replica_client.replica_open()
+        grpc_replica_client.replica_expand(EXPANDED_SIZE)
+
+    snap_name_1 = get_expansion_snapshot_name(grpc_replica_client_1)
+    snap_name_2 = get_expansion_snapshot_name(grpc_replica_client_2)
+
+    # Each expansion snapshot name embeds its own volume name ...
+    assert snap_name_1 == "expand-{}-{}".format(
+        EXPANDED_SIZE_STR, volume_name_1)
+    assert snap_name_2 == "expand-{}-{}".format(
+        EXPANDED_SIZE_STR, volume_name_2)
+    # ... so two volumes of the same size never collide.
+    assert snap_name_1 != snap_name_2
 
 
 def test_single_replica_failure_during_engine_start(bin):  # NOQA

--- a/integration/data/test_restore.py
+++ b/integration/data/test_restore.py
@@ -367,10 +367,13 @@ def test_inc_restore_with_rebuild_and_expansion(
     snaps_info = cmd.snapshot_info(dr_address)
     assert len(snaps_info) == 2
     volume_head_name = "volume-head"
-    snap_name = "expand-" + EXPANDED_SIZE_STR
     head_info = snaps_info[volume_head_name]
+    # The replica is launched without a volume name, so the expansion snapshot
+    # falls back to the size-only form "expand-<size>". Discover it from the
+    # head's parent rather than recomputing it.
+    snap_name = head_info["parent"]
+    assert snap_name == "expand-" + EXPANDED_SIZE_STR
     assert head_info["name"] == volume_head_name
-    assert head_info["parent"] == snap_name
     assert not head_info["children"]
     assert head_info["usercreated"] is False
     snap_info = snaps_info[snap_name]

--- a/pkg/replica/backup_test.go
+++ b/pkg/replica/backup_test.go
@@ -28,7 +28,7 @@ func (s *TestSuite) TestBackup(c *C) {
 	err = os.Chdir(dir)
 	c.Assert(err, IsNil)
 
-	r, err := New(context.Background(), 10*mb, bs, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 10*mb)
+	r, err := New(context.Background(), 10*mb, bs, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 10*mb, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -106,7 +106,7 @@ func (s *TestSuite) testBackupWithBackups(c *C, backingFile *backingfile.Backing
 	c.Assert(err, IsNil)
 	volume := "test"
 
-	r, err := New(context.Background(), 10*mb, bs, dir, backingFile, false, false, 250, 0, false, false, types.ReplicaStateInitial, 10*mb)
+	r, err := New(context.Background(), 10*mb, bs, dir, backingFile, false, false, 250, 0, false, false, types.ReplicaStateInitial, 10*mb, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()

--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -49,6 +49,7 @@ type Replica struct {
 	ctx             context.Context
 	volume          diffDisk
 	dir             string
+	volumeName      string
 	info            Info
 	diskData        map[string]*disk
 	diskChildrenMap map[string]map[string]bool
@@ -148,18 +149,18 @@ func ReadInfo(dir string) (Info, error) {
 }
 
 func New(ctx context.Context, size, sectorSize int64, dir string, backingFile *backingfile.BackingFile,
-	disableRevCounter, unmapMarkDiskChainRemoved bool, snapshotMaxCount int, snapshotMaxSize int64, encrypted, isUpgrade bool, state types.ReplicaState, expectedBackendSize int64) (*Replica, error) {
-	return construct(ctx, false, size, sectorSize, dir, "", backingFile, disableRevCounter, unmapMarkDiskChainRemoved, snapshotMaxCount, snapshotMaxSize, encrypted, isUpgrade, state, expectedBackendSize)
+	disableRevCounter, unmapMarkDiskChainRemoved bool, snapshotMaxCount int, snapshotMaxSize int64, encrypted, isUpgrade bool, state types.ReplicaState, expectedBackendSize int64, volumeName string) (*Replica, error) {
+	return construct(ctx, false, size, sectorSize, dir, "", backingFile, disableRevCounter, unmapMarkDiskChainRemoved, snapshotMaxCount, snapshotMaxSize, encrypted, isUpgrade, state, expectedBackendSize, volumeName)
 }
 
 func NewReadOnly(ctx context.Context, dir, head string, backingFile *backingfile.BackingFile) (*Replica, error) {
 	// size and sectorSize don't matter because they will be read from metadata
 	// snapshotMaxCount and SnapshotMaxSize don't matter because readonly replica can't create a new disk
-	return construct(ctx, true, 0, diskutil.ReplicaSectorSize, dir, head, backingFile, false, false, types.MaximumTotalSnapshotCount, 0, false, false, types.ReplicaStateClosed, 0)
+	return construct(ctx, true, 0, diskutil.ReplicaSectorSize, dir, head, backingFile, false, false, types.MaximumTotalSnapshotCount, 0, false, false, types.ReplicaStateClosed, 0, "")
 }
 
 func construct(ctx context.Context, readonly bool, size, sectorSize int64, dir, head string, backingFile *backingfile.BackingFile,
-	disableRevCounter, unmapMarkDiskChainRemoved bool, snapshotMaxCount int, snapshotMaxSize int64, encrypted, isUpgrade bool, state types.ReplicaState, expectedBackendSize int64) (*Replica, error) {
+	disableRevCounter, unmapMarkDiskChainRemoved bool, snapshotMaxCount int, snapshotMaxSize int64, encrypted, isUpgrade bool, state types.ReplicaState, expectedBackendSize int64, volumeName string) (*Replica, error) {
 	if size%sectorSize != 0 {
 		return nil, fmt.Errorf("size %d not a multiple of sector size %d", size, sectorSize)
 	}
@@ -171,6 +172,7 @@ func construct(ctx context.Context, readonly bool, size, sectorSize int64, dir, 
 	r := &Replica{
 		ctx:                       ctx,
 		dir:                       dir,
+		volumeName:                volumeName,
 		activeDiskData:            make([]*disk, 1),
 		diskData:                  make(map[string]*disk),
 		diskChildrenMap:           map[string]map[string]bool{},
@@ -331,7 +333,7 @@ func (r *Replica) SetRebuilding(rebuilding bool) error {
 }
 
 func (r *Replica) Reload() (*Replica, error) {
-	newReplica, err := New(r.ctx, r.info.Size, r.info.SectorSize, r.dir, r.info.BackingFile, r.revisionCounterDisabled, r.unmapMarkDiskChainRemoved, r.snapshotMaxCount, r.snapshotMaxSize, r.info.Encrypted, false, types.ReplicaStateDirty, r.info.Size)
+	newReplica, err := New(r.ctx, r.info.Size, r.info.SectorSize, r.dir, r.info.BackingFile, r.revisionCounterDisabled, r.unmapMarkDiskChainRemoved, r.snapshotMaxCount, r.snapshotMaxSize, r.info.Encrypted, false, types.ReplicaStateDirty, r.info.Size, r.volumeName)
 	if err != nil {
 		return nil, err
 	}
@@ -1316,7 +1318,7 @@ func (r *Replica) Expand(size int64) (err error) {
 
 	// Will create a new head with the expanded size and write the new size into the meta file
 	if err := r.createDisk(
-		diskutil.GenerateExpansionSnapshotName(size), false, util.Now(),
+		diskutil.GenerateExpansionSnapshotName(r.volumeName, size), false, util.Now(),
 		diskutil.GenerateExpansionSnapshotLabels(size), size); err != nil {
 		return err
 	}

--- a/pkg/replica/replica_test.go
+++ b/pkg/replica/replica_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/longhorn/longhorn-engine/pkg/backingfile"
 	"github.com/longhorn/longhorn-engine/pkg/types"
 	"github.com/longhorn/longhorn-engine/pkg/util"
+
+	diskutil "github.com/longhorn/longhorn-engine/pkg/util/disk"
 	. "gopkg.in/check.v1"
 )
 
@@ -62,12 +64,43 @@ func (s *TestSuite) TestCreate(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
 		c.Assert(errClose, IsNil)
 	}()
+}
+
+func (s *TestSuite) TestExpandSnapshotNameUsesVolumeName(c *C) {
+	dir, err := os.MkdirTemp("", "replica")
+	c.Assert(err, IsNil)
+	defer func() {
+		errRemove := os.RemoveAll(dir)
+		c.Assert(errRemove, IsNil)
+	}()
+
+	const volumeName = "test-vol"
+	const initialSize = int64(diskutil.VolumeSectorSize)
+	const expandedSize = int64(2 * diskutil.VolumeSectorSize)
+
+	r, err := New(context.Background(), initialSize, diskutil.ReplicaSectorSize, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, initialSize, volumeName)
+	c.Assert(err, IsNil)
+	defer func() {
+		errClose := r.Close()
+		c.Assert(errClose, IsNil)
+	}()
+
+	err = r.Expand(expandedSize)
+	c.Assert(err, IsNil)
+
+	// The expansion snapshot name must include the volume name so that all
+	// replicas of the same volume agree on it while different volumes differ.
+	expectedSnapName := diskutil.GenerateExpansionSnapshotName(volumeName, expandedSize)
+	expectedSnapDiskName := diskutil.GenerateSnapshotDiskName(expectedSnapName)
+	c.Assert(r.info.Parent, Equals, expectedSnapDiskName)
+	_, ok := r.diskData[expectedSnapDiskName]
+	c.Assert(ok, Equals, true)
 }
 
 func getNow() string {
@@ -84,7 +117,7 @@ func (s *TestSuite) TestSnapshot(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -175,7 +208,7 @@ func (s *TestSuite) TestRevert(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -293,7 +326,7 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -374,7 +407,7 @@ func (s *TestSuite) TestRemoveLast(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -426,7 +459,7 @@ func (s *TestSuite) TestRemoveMiddle(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -478,7 +511,7 @@ func (s *TestSuite) TestRemoveFirst(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -515,7 +548,7 @@ func (s *TestSuite) TestRemoveOutOfChain(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -597,7 +630,7 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -743,7 +776,7 @@ func (s *TestSuite) TestRead(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9*b)
+	r, err := New(context.Background(), 9*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -783,7 +816,7 @@ func (s *TestSuite) TestReadBackingFileSmallerThanVolume(c *C) {
 		Disk: f,
 	}
 
-	r, err := New(context.Background(), 5*b, b, dir, backing, false, false, 250, 0, false, false, types.ReplicaStateInitial, 5*b)
+	r, err := New(context.Background(), 5*b, b, dir, backing, false, false, 250, 0, false, false, types.ReplicaStateInitial, 5*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -870,7 +903,7 @@ func (s *TestSuite) TestWrite(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9*b)
+	r, err := New(context.Background(), 9*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -898,7 +931,7 @@ func (s *TestSuite) TestSnapshotReadWrite(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 3*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 3*b)
+	r, err := New(context.Background(), 3*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 3*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -969,7 +1002,7 @@ func (s *TestSuite) TestBackingFile(c *C) {
 		Disk: f,
 	}
 
-	r, err := New(context.Background(), 3*b, b, dir, backing, false, false, 250, 0, false, false, types.ReplicaStateInitial, 3*b)
+	r, err := New(context.Background(), 3*b, b, dir, backing, false, false, 250, 0, false, false, types.ReplicaStateInitial, 3*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -1008,7 +1041,7 @@ func (s *TestSuite) partialWriteRead(c *C, totalLength, writeLength, writeOffset
 	buf := make([]byte, totalLength)
 	fill(buf, 3)
 
-	r, err := New(context.Background(), totalLength, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, totalLength)
+	r, err := New(context.Background(), totalLength, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, totalLength, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -1062,7 +1095,7 @@ func (s *TestSuite) testPartialRead(c *C, totalLength int64, readBuf []byte, off
 	buf := make([]byte, totalLength)
 	fill(buf, 3)
 
-	r, err := New(context.Background(), totalLength, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, totalLength)
+	r, err := New(context.Background(), totalLength, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, totalLength, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -1139,7 +1172,7 @@ func (s *TestSuite) TestForceRemoveDiffDisk(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -1189,7 +1222,7 @@ func (s *TestSuite) TestUnmapMarkDiskRemoved(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 9, 3, dir, nil, false, true, 250, 0, false, false, types.ReplicaStateInitial, 9)
+	r, err := New(context.Background(), 9, 3, dir, nil, false, true, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()
@@ -1246,7 +1279,7 @@ func (s *TestSuite) TestUnmap(c *C) {
 		c.Assert(errRemove, IsNil)
 	}()
 
-	r, err := New(context.Background(), 8*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 8*b)
+	r, err := New(context.Background(), 8*b, b, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 8*b, "")
 	c.Assert(err, IsNil)
 	defer func() {
 		errClose := r.Close()

--- a/pkg/replica/server.go
+++ b/pkg/replica/server.go
@@ -17,6 +17,7 @@ type Server struct {
 	ctx                       context.Context
 	r                         *Replica
 	dir                       string
+	volumeName                string
 	sectorSize                int64
 	backing                   *backingfile.BackingFile
 	revisionCounterDisabled   bool
@@ -27,10 +28,11 @@ type Server struct {
 }
 
 func NewServer(ctx context.Context, dir string, backing *backingfile.BackingFile, sectorSize int64, disableRevCounter, unmapMarkDiskChainRemoved bool,
-	snapshotMaxCount int, snapshotMaxSize int64, encrypted bool) *Server {
+	snapshotMaxCount int, snapshotMaxSize int64, encrypted bool, volumeName string) *Server {
 	return &Server{
 		ctx:                       ctx,
 		dir:                       dir,
+		volumeName:                volumeName,
 		backing:                   backing,
 		sectorSize:                sectorSize,
 		revisionCounterDisabled:   disableRevCounter,
@@ -60,7 +62,7 @@ func (s *Server) Create(size int64) error {
 	sectorSize := s.getSectorSize()
 
 	logrus.Infof("Creating replica %s, size %d/%d", s.dir, size, sectorSize)
-	r, err := New(s.ctx, size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved, s.snapshotMaxCount, s.snapshotMaxSize, s.encrypted, false, state, size)
+	r, err := New(s.ctx, size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved, s.snapshotMaxCount, s.snapshotMaxSize, s.encrypted, false, state, size, s.volumeName)
 	if err != nil {
 		return err
 	}
@@ -80,7 +82,7 @@ func (s *Server) Open(isUpgrade bool, expectedBackendSize int64) error {
 	sectorSize := s.getSectorSize()
 
 	logrus.Infof("Opening replica: dir %s, size %d, sector size %d, state: %v, upgrading: %v, expected backend size: %v", s.dir, info.Size, sectorSize, state, isUpgrade, expectedBackendSize)
-	r, err := New(s.ctx, info.Size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved, s.snapshotMaxCount, s.snapshotMaxSize, s.encrypted, isUpgrade, state, expectedBackendSize)
+	r, err := New(s.ctx, info.Size, sectorSize, s.dir, s.backing, s.revisionCounterDisabled, s.unmapMarkDiskChainRemoved, s.snapshotMaxCount, s.snapshotMaxSize, s.encrypted, isUpgrade, state, expectedBackendSize, s.volumeName)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/disk/disk.go
+++ b/pkg/util/disk/disk.go
@@ -42,8 +42,18 @@ func GetSnapshotNameFromDiskName(diskName string) (string, error) {
 	return result, nil
 }
 
-func GenerateExpansionSnapshotName(size int64) string {
-	return fmt.Sprintf(expansionSnapshotInfix, size)
+// GenerateExpansionSnapshotName includes the volume name in the expansion
+// snapshot name. All replicas of a volume share the same volume name, so they
+// generate the same name, while different volumes get different names. This
+// avoids Snapshot CR name collisions within the same Longhorn namespace when
+// two volumes are expanded to the same size. When the volume name is empty, it
+// falls back to the size-only form to keep the result a valid DNS-1123 name.
+func GenerateExpansionSnapshotName(volumeName string, size int64) string {
+	name := fmt.Sprintf(expansionSnapshotInfix, size)
+	if volumeName != "" {
+		name += "-" + volumeName
+	}
+	return name
 }
 
 func GenerateExpansionSnapshotLabels(size int64) map[string]string {

--- a/pkg/util/disk/disk_test.go
+++ b/pkg/util/disk/disk_test.go
@@ -1,0 +1,45 @@
+package diskutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) TestGenerateExpansionSnapshotName(c *C) {
+	const size = int64(4096)
+
+	// All replicas of a volume share the same volume name, so the generated
+	// name must be deterministic for a given volume name and size.
+	name := GenerateExpansionSnapshotName("vol-a", size)
+	c.Assert(name, Equals, fmt.Sprintf(expansionSnapshotInfix, size)+"-vol-a")
+	c.Assert(name, Equals, GenerateExpansionSnapshotName("vol-a", size))
+
+	// The name keeps the size-based infix as a prefix so the snapshot remains
+	// identifiable as an expansion snapshot.
+	c.Assert(strings.HasPrefix(name, fmt.Sprintf(expansionSnapshotInfix, size)+"-"), Equals, true)
+
+	// Different volumes expanded to the same size must get different names so
+	// they do not collide on a Snapshot CR within the same namespace.
+	c.Assert(GenerateExpansionSnapshotName("vol-a", size),
+		Not(Equals), GenerateExpansionSnapshotName("vol-b", size))
+
+	// An empty volume name falls back to the size-only form so the result stays
+	// a valid DNS-1123 name (no trailing dash).
+	c.Assert(GenerateExpansionSnapshotName("", size), Equals, fmt.Sprintf(expansionSnapshotInfix, size))
+}
+
+func (s *TestSuite) TestGenerateExpansionSnapshotLabels(c *C) {
+	const size = int64(8192)
+
+	labels := GenerateExpansionSnapshotLabels(size)
+	c.Assert(labels[replicaExpansionLabelKey], Equals, "8192")
+}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13386

#### What this PR does / why we need it:


The volume-expansion system snapshot was named "expand-<size>", derived solely from the target size. Because Snapshot CRs are cluster-scoped in longhorn-manager, two volumes expanded to the same size produced the same snapshot name and collided.

Generate the name as `expand-<size>-<volumeName>` instead. The volume name is plumbed from the replica Server through to the Replica so the name stays deterministic across all replicas of a volume while being unique across volumes.



#### Special notes for your reviewer:

#### Additional documentation or context
