### PR TITLE
fix(replica): persist snapshot's own name in its disk meta file

### DIFF
--- a/pkg/replica/replica.go
+++ b/pkg/replica/replica.go
@@ -1016,7 +1016,11 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 	r.diskData[newHeadDisk.Name] = &newHeadDisk
 	if newSnapName != "" {
 		r.addChildDisk(newSnapName, newHeadDisk.Name)
+		// The old head's disk struct is reused for the new snapshot. Keep a copy so the rollback
+		// can restore the head if a later step fails.
+		oldHeadDisk := *r.diskData[oldHead]
 		r.diskData[newSnapName] = r.diskData[oldHead]
+		r.diskData[newSnapName].Name = newSnapName
 		r.diskData[newSnapName].UserCreated = userCreated
 		r.diskData[newSnapName].Created = created
 		r.diskData[newSnapName].Labels = labels
@@ -1024,6 +1028,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 			delete(r.diskData, newHeadDisk.Name)
 			delete(r.diskData, newSnapName)
 			delete(r.diskChildrenMap, newSnapName)
+			*r.diskData[oldHead] = oldHeadDisk
 			return nil
 		})
 
@@ -1034,7 +1039,6 @@ func (r *Replica) createDisk(name string, userCreated bool, created string, labe
 		rollbackFuncList = append(rollbackFuncList, snapMetaEncodeRollbackFunc)
 
 		r.updateChildDisk(oldHead, newSnapName)
-		r.activeDiskData[len(r.activeDiskData)-1].Name = newSnapName
 	}
 	delete(r.diskData, oldHead)
 

--- a/pkg/replica/replica_test.go
+++ b/pkg/replica/replica_test.go
@@ -200,6 +200,95 @@ func (s *TestSuite) TestSnapshot(c *C) {
 	c.Assert(disks["volume-head-002.img"].Size, Equals, "0")
 }
 
+func (s *TestSuite) TestSnapshotDiskMetaName(c *C) {
+	dir, err := os.MkdirTemp("", "replica")
+	c.Assert(err, IsNil)
+	defer func() {
+		errRemove := os.RemoveAll(dir)
+		c.Assert(errRemove, IsNil)
+	}()
+
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
+	c.Assert(err, IsNil)
+	defer func() {
+		errClose := r.Close()
+		c.Assert(errClose, IsNil)
+	}()
+
+	err = r.Snapshot("000", true, getNow(), nil)
+	c.Assert(err, IsNil)
+	err = r.Snapshot("001", false, getNow(), nil)
+	c.Assert(err, IsNil)
+
+	for _, name := range []string{"volume-snap-000.img", "volume-snap-001.img", "volume-head-002.img"} {
+		c.Assert(r.diskData[name].Name, Equals, name)
+
+		var d disk
+		err = r.unmarshalFile(name+diskutil.DiskMetadataSuffix, &d)
+		c.Assert(err, IsNil)
+		c.Assert(d.Name, Equals, name)
+	}
+}
+
+func (s *TestSuite) TestSnapshotMetaWriteFailureRollback(c *C) {
+	dir, err := os.MkdirTemp("", "replica")
+	c.Assert(err, IsNil)
+	defer func() {
+		errRemove := os.RemoveAll(dir)
+		c.Assert(errRemove, IsNil)
+	}()
+
+	r, err := New(context.Background(), 9, 3, dir, nil, false, false, 250, 0, false, false, types.ReplicaStateInitial, 9, "")
+	c.Assert(err, IsNil)
+	defer func() {
+		errClose := r.Close()
+		c.Assert(errClose, IsNil)
+	}()
+
+	err = r.Snapshot("000", true, getNow(), nil)
+	c.Assert(err, IsNil)
+	head := r.info.Head
+	c.Assert(head, Equals, "volume-head-001.img")
+	headDisk := *r.diskData[head]
+
+	// encodeToFile() writes <file>.tmp first; a directory in its place makes the snapshot meta write fail
+	failedSnap := "volume-snap-001.img"
+	err = os.Mkdir(r.diskPath(failedSnap+diskutil.DiskMetadataSuffix+tmpFileSuffix), 0755)
+	c.Assert(err, IsNil)
+
+	err = r.Snapshot("001", true, getNow(), map[string]string{"key": "value"})
+	c.Assert(err, ErrorMatches, "(?s).*failed to create the tmp file.*")
+
+	// The head must be left exactly as it was before the failed snapshot
+	c.Assert(r.info.Head, Equals, head)
+	c.Assert(*r.diskData[head], DeepEquals, headDisk)
+	c.Assert(r.activeDiskData[len(r.activeDiskData)-1].Name, Equals, head)
+	_, exists := r.diskData[failedSnap]
+	c.Assert(exists, Equals, false)
+	_, err = os.Stat(r.diskPath(failedSnap))
+	c.Assert(os.IsNotExist(err), Equals, true)
+	_, err = os.Stat(r.diskPath(failedSnap + diskutil.DiskMetadataSuffix))
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	disks := r.ListDisks()
+	c.Assert(len(disks), Equals, 2)
+	c.Assert(disks[head].Parent, Equals, "volume-snap-000.img")
+	c.Assert(len(disks["volume-snap-000.img"].Children), Equals, 1)
+	c.Assert(disks["volume-snap-000.img"].Children[head], Equals, true)
+
+	// The next snapshot succeeds and every meta file carries its own name
+	err = r.Snapshot("002", false, getNow(), nil)
+	c.Assert(err, IsNil)
+	for _, name := range []string{"volume-snap-000.img", "volume-snap-002.img", "volume-head-002.img"} {
+		c.Assert(r.diskData[name].Name, Equals, name)
+
+		var d disk
+		err = r.unmarshalFile(name+diskutil.DiskMetadataSuffix, &d)
+		c.Assert(err, IsNil)
+		c.Assert(d.Name, Equals, name)
+	}
+}
+
 func (s *TestSuite) TestRevert(c *C) {
 	dir, err := os.MkdirTemp("", "replica")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13728

#### What this PR does / why we need it:

## Problem

After taking a snapshot, the persisted `volume-snap-<name>.img.meta` file carries the previous head's filename in its `Name` field instead of the snapshot's own filename:

```
$ cat volume-snap-000.img.meta
{"Name":"volume-head-000.img","Parent":"","Removed":false,"UserCreated":true,...}
```

Every snapshot meta file written by `createDisk()` is affected.

## Root cause

`pkg/replica/replica.go`, `createDisk()` (line numbers on current master):

- L1019: `r.diskData[newSnapName] = r.diskData[oldHead]` reuses the old head's `disk` struct (pointer copy) for the new snapshot and updates `UserCreated`, `Created` and `Labels` on it, but not `Name`.
- L1030: `r.encodeToFile(r.diskData[newSnapName], newSnapName+".meta")` persists that struct while `Name` still reads `volume-head-NNN.img`.
- L1037: `r.activeDiskData[len(r.activeDiskData)-1].Name = newSnapName` corrects `Name` on the same struct, but only after the meta file has already been written.

The in-memory state ends up correct (the `activeDiskData` tail and `r.diskData[oldHead]` point at the same struct, and `readDiskData()` re-derives `Name` from the filename on reload), so only the on-disk meta file is wrong.

## Fix

Set `r.diskData[newSnapName].Name = newSnapName` together with the other field updates, right after the pointer copy and before `encodeToFile()`. The later `activeDiskData[...].Name = newSnapName` assignment becomes redundant (same struct) and is removed.

Because that struct is still the current head's until the snapshot completes, `createDisk()` now keeps a copy of it (`oldHeadDisk`) and restores it in the existing rollback closure that removes the new map keys. If the snapshot meta write fails (for example ENOSPC), the head keeps its own `Name` instead of the just-removed `volume-snap-<name>.img`, and the `UserCreated`/`Created`/`Labels` values set for the snapshot no longer leak onto the head either.

Existing meta files written by earlier versions are not rewritten by this change; they are still loaded correctly because `readDiskData()` takes the name from the filename.

## How tested

Added two tests in `pkg/replica/replica_test.go`:

- `TestSnapshotDiskMetaName`: takes two snapshots on a temp-dir replica, then for each snapshot disk and the head reads back `<disk>.meta` and asserts `Name` equals the disk filename (and that `r.diskData[<disk>].Name` matches).
- `TestSnapshotMetaWriteFailureRollback`: creates a directory at `volume-snap-001.img.meta.tmp` so `encodeToFile()` fails for the snapshot meta, asserts `Snapshot()` returns the tmp-file error, that the head's in-memory `disk` struct is byte-for-byte what it was before the call (`Name`, `UserCreated`, `Created`, `Labels`), that `activeDiskData`'s tail and `ListDisks()` are unchanged and the failed snapshot's files are gone, and that a following `Snapshot("002")` succeeds with correct `Name` values in every meta file. Without the restore in the rollback this test fails on the head's `Name` (`volume-snap-001.img` instead of `volume-head-001.img`).

Before the fix:

```
FAIL: replica_test.go:203: TestSuite.TestSnapshotDiskMetaName

replica_test.go:229:
    c.Assert(d.Name, Equals, name)
... obtained string = "volume-head-000.img"
... expected string = "volume-snap-000.img"

OOPS: 0 passed, 1 FAILED
FAIL	github.com/longhorn/longhorn-engine/pkg/replica	2.015s
```

After the fix:

```
ok  	github.com/longhorn/longhorn-engine/pkg/replica	5.019s   (-check.f 'TestSnapshotDiskMetaName$|TestSnapshotMetaWriteFailureRollback$')
ok  	github.com/longhorn/longhorn-engine/pkg/replica	43.529s  (full package)
```

`go build ./...`, `go vet ./pkg/replica/`, `gofmt -l` and `golangci-lint run ./pkg/replica/...` are clean.

#### Special notes for your reviewer:

- Per the discussion on the issue, the old (wrong) `Name` value incidentally recorded which head the snapshot was taken from. This PR only corrects the field; persisting snapshot creation-order information explicitly, and back-filling existing replicas' meta files, are left as follow-ups if wanted.
- No behavior change for reads/writes or for reload: `readDiskData()` already overrides `Name` with the filename-derived value.
- The rollback restore is new behavior only on the failure path: previously a failed snapshot meta write left the head struct with the snapshot's `UserCreated`/`Created`/`Labels`; now it is restored completely.

#### Additional documentation or context

## Links

- https://github.com/longhorn/longhorn/issues/13728

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
